### PR TITLE
fix(app): unblock chat Stop button by reaping child via supervisor task

### DIFF
--- a/packages/app/src-tauri/src/chat_host.rs
+++ b/packages/app/src-tauri/src/chat_host.rs
@@ -26,15 +26,22 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
 use tauri::{AppHandle, Emitter};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::Mutex;
+use tokio::process::{ChildStdin, Command};
+use tokio::sync::{oneshot, Mutex};
+
+/// Bound on how long `shutdown()` waits for the supervisor to reap the child.
+/// Long enough for `claude` to flush an in-flight turn after SIGTERM, short
+/// enough that a wedged child can't block window close or session switch.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Emitted when the child exits. `code` is the raw exit status or `None` if
 /// the OS killed the process with a signal.
@@ -45,9 +52,27 @@ struct ExitPayload {
 
 /// Public handle to the running chat child. Held in Tauri state as
 /// `ManagedChatHost` so commands can share it with the window-close hook.
+///
+/// Ownership model: the `Child` is owned exclusively by a supervisor task
+/// spawned in `spawn()`. Other code never locks the child — it communicates
+/// with the supervisor by sending on `cancel_tx` and awaiting `done_rx`.
+/// This avoids the deadlock the prior `Arc<Mutex<Option<Child>>>` design hit
+/// when `shutdown()` raced the supervisor's `child.wait().await` for the
+/// same lock.
 pub struct ChatHost {
-    child: Arc<Mutex<Option<Child>>>,
-    stdin: Arc<Mutex<Option<ChildStdin>>>,
+    /// Sends a one-shot cancel signal to the supervisor task. `take()`-ed on
+    /// the first `shutdown()` call so subsequent calls are no-ops.
+    cancel_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Resolves once the supervisor has reaped the child and emitted
+    /// `chat-exit`. Lets `shutdown()` block (with a timeout) on full teardown
+    /// before returning, which the window-close hook relies on.
+    done_rx: Mutex<Option<oneshot::Receiver<()>>>,
+    /// Stdin handle for `write_line`. Dropped on shutdown so the child sees
+    /// EOF, which lets a well-behaved `claude` exit cleanly without a kill.
+    stdin: Mutex<Option<ChildStdin>>,
+    /// Liveness flag flipped by the supervisor on exit. Lock-free read for
+    /// the hot `is_alive()` path used by `ensure_chat_running`.
+    alive: Arc<AtomicBool>,
     session_path: PathBuf,
 }
 
@@ -101,9 +126,6 @@ impl ChatHost {
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
 
-        let child_arc = Arc::new(Mutex::new(Some(child)));
-        let stdin_arc = Arc::new(Mutex::new(stdin));
-
         if let Some(out) = stdout {
             let app_for_task = app.clone();
             tauri::async_runtime::spawn(async move {
@@ -117,29 +139,36 @@ impl ChatHost {
             });
         }
 
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_for_task = alive.clone();
         let app_for_exit = app.clone();
-        let child_for_wait = child_arc.clone();
+
+        // Supervisor: sole owner of `child`. Races a cancel signal against
+        // the natural exit so neither `shutdown()` nor `wait()` ever needs to
+        // hold a lock on the child. On cancel we send SIGTERM via
+        // `start_kill` and still `wait()` to reap, so we don't leave a zombie.
         tauri::async_runtime::spawn(async move {
-            let code = {
-                let mut guard = child_for_wait.lock().await;
-                match guard.as_mut() {
-                    Some(c) => match c.wait().await {
-                        Ok(status) => status.code(),
-                        Err(_) => None,
-                    },
-                    None => None,
+            let exit_code = tokio::select! {
+                _ = cancel_rx => {
+                    let _ = child.start_kill();
+                    child.wait().await.ok().and_then(|s| s.code())
                 }
+                res = child.wait() => res.ok().and_then(|s| s.code()),
             };
-            {
-                let mut guard = child_for_wait.lock().await;
-                *guard = None;
-            }
-            let _ = app_for_exit.emit("chat-exit", ExitPayload { code });
+            alive_for_task.store(false, Ordering::SeqCst);
+            // `done_tx` may have no receiver if `shutdown()` timed out and
+            // dropped the rx — that's fine, send is best-effort.
+            let _ = done_tx.send(());
+            let _ = app_for_exit.emit("chat-exit", ExitPayload { code: exit_code });
         });
 
         Ok(Self {
-            child: child_arc,
-            stdin: stdin_arc,
+            cancel_tx: Mutex::new(Some(cancel_tx)),
+            done_rx: Mutex::new(Some(done_rx)),
+            stdin: Mutex::new(stdin),
+            alive,
             session_path,
         })
     }
@@ -164,26 +193,37 @@ impl ChatHost {
         Ok(())
     }
 
-    /// Graceful shutdown — close stdin (signals EOF), then best-effort kill.
+    /// Graceful shutdown — close stdin (so a well-behaved child exits on
+    /// EOF), signal the supervisor to cancel, then await reap with a timeout.
+    /// Idempotent: a second call after exit no-ops because both `cancel_tx`
+    /// and `done_rx` are `take()`-ed on first use.
     pub async fn shutdown(&self) -> Result<()> {
+        // Drop stdin first. If the child exits cleanly on EOF, the
+        // supervisor's `wait()` arm of the select wins naturally and the
+        // cancel signal below is harmlessly ignored.
         {
             let mut guard = self.stdin.lock().await;
             *guard = None;
         }
-        let mut guard = self.child.lock().await;
-        if let Some(mut child) = guard.take() {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
+        if let Some(tx) = self.cancel_tx.lock().await.take() {
+            // Send error means the supervisor already exited — that's fine.
+            let _ = tx.send(());
+        }
+        let rx = self.done_rx.lock().await.take();
+        if let Some(rx) = rx {
+            // Bound the wait so a wedged child can't block window close or
+            // session switch. After timeout `kill_on_drop(true)` on the
+            // Command still cleans up if `ChatHost` is dropped.
+            let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, rx).await;
         }
         Ok(())
     }
 
-    /// `false` after the child has exited (or been killed). The waiter
-    /// task nulls the internal slot on exit, so `chat_send` can detect a
-    /// dead host and respawn on the next turn without the frontend having
-    /// to orchestrate an explicit "start".
+    /// `false` after the supervisor has reaped the child. `chat_send` checks
+    /// this to decide whether to respawn, so it must be cheap — backed by an
+    /// `AtomicBool` rather than a mutex.
     pub async fn is_alive(&self) -> bool {
-        self.child.lock().await.is_some()
+        self.alive.load(Ordering::SeqCst)
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- Stop 버튼이 클릭해도 아무 반응이 없던 버그 수정. 원인은 `ChatHost`에서 waiter task가 `child.lock().await`를 잡은 채 `child.wait().await`로 무한 대기 중이라, `shutdown()`이 같은 lock을 시도하면서 발생한 deadlock이었음.
- `Child`를 더 이상 mutex로 감싸지 않고 supervisor task가 owned로 보유. `tokio::select!`로 oneshot cancel signal vs natural exit를 경합시키므로, 그 어떤 코드도 child를 lock할 필요가 없어 deadlock이 구조적으로 불가능.
- `shutdown()`은 (1) stdin drop → EOF로 자연 종료 유도, (2) cancel signal 전송 → SIGTERM, (3) `done_rx`를 5초 timeout과 함께 await로 reap 동기화. wedged child가 window close나 session switch를 막지 못하도록 timeout 가드 적용.
- `is_alive()`는 `AtomicBool` 로드로 변경 (lock-free).

## Why this design
- `child.lock()`을 잡고 `child.wait().await`를 호출하는 패턴은 본질적으로 lock 점유 기간이 process lifetime과 같아짐 → 같은 lock을 잡으려는 모든 시도가 막힘.
- supervisor task가 child의 단독 owner가 되면 lock 자체가 필요 없음. 외부와는 oneshot 채널로만 통신 → 점유 시간이 µs 단위.
- `kill_on_drop(true)`는 그대로 두어 최종 안전망으로 유지.

## Test plan
- [x] `cargo check` 통과
- [x] `cargo test --lib` 22/22 통과 (기존 테스트 회귀 없음)
- [ ] 앱을 실제로 띄워서 Stop 버튼이 in-flight turn을 즉시 중단하는지 수동 확인 (sidecar binary 빌드 필요한 환경이라 PR 생성 시점에는 미실행)
- [ ] 연속 Stop → Send 플로우에서 child가 정상 respawn되는지 확인
- [ ] 창 닫기/세션 전환 시에도 deadlock 없이 종료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)