### PR TITLE
fix: 5 Excalidraw/chat bugs blocking flowchart generation

### DIFF
--- a/packages/app/src/mcp/reconcile.ts
+++ b/packages/app/src/mcp/reconcile.ts
@@ -36,6 +36,13 @@ interface ReconcilerInput {
   fresh: readonly ExcalidrawElement[];
   /** Files associated with the fresh compile (passed through unchanged). */
   files: BinaryFiles;
+  /**
+   * Primitive ids whose local state must not be overwritten by the next
+   * compile. Elements whose `drawcastPrimitiveId` lies in this set are
+   * returned as a copy of their prior version (geometry + identity
+   * preserved). Omit / leave empty when nothing is locked.
+   */
+  lockedIds?: ReadonlySet<string>;
 }
 
 export interface ReconcilerOutput {
@@ -62,7 +69,7 @@ function keyFor(primitiveId: string, type: string): string {
  * Pure: does not mutate either input; returns a new object.
  */
 export function reconcileElements(input: ReconcilerInput): ReconcilerOutput {
-  const { prev, fresh, files } = input;
+  const { prev, fresh, files, lockedIds } = input;
   if (prev === null || prev.length === 0) {
     // No prior frame — nothing to stabilise against. Copy the fresh array
     // so callers never see internal references.
@@ -81,6 +88,11 @@ export function reconcileElements(input: ReconcilerInput): ReconcilerOutput {
     if (pid === null) return { ...el };
     const match = prevByKey.get(keyFor(pid, el.type));
     if (match === undefined) return { ...el };
+    // Edit-locked primitives: keep the prior element verbatim so a fresh
+    // MCP snapshot can't clobber the user's local drag / delete / resize.
+    if (lockedIds !== undefined && lockedIds.has(pid)) {
+      return { ...match };
+    }
     return {
       ...el,
       id: match.id,

--- a/packages/app/src/panels/CanvasPanel.tsx
+++ b/packages/app/src/panels/CanvasPanel.tsx
@@ -147,6 +147,10 @@ export function CanvasPanel(): JSX.Element {
   const storeLocked = useSceneStore((s) => s.locked);
   const setSelection = useSceneStore((s) => s.setSelection);
   const themeMode = useSettingsStore((s) => s.themeMode);
+  // Subscribed so the effect below re-runs whenever the local lock set
+  // changes — otherwise a freshly locked primitive would wait until the
+  // NEXT MCP snapshot before its geometry becomes sticky.
+  const lockedIds = useEditLockStore((s) => s.lockedIds);
   const client = useMcp();
   const connected = useMcpConnected();
   const [apiReady, setApiReady] = useState(false);
@@ -208,6 +212,7 @@ export function CanvasPanel(): JSX.Element {
       prev: prevReconciledElementsRef.current,
       fresh: compiled.elements,
       files: compiled.files,
+      lockedIds,
     });
     prevReconciledElementsRef.current = out.elements;
     const versions = new Map<string, number>();
@@ -220,7 +225,7 @@ export function CanvasPanel(): JSX.Element {
     if (files.length > 0) {
       api.addFiles(files);
     }
-  }, [apiReady, compiled]);
+  }, [apiReady, compiled, lockedIds]);
 
   // Inbound selection sync: when sceneStore.selection changes (pushed by
   // the server or the setSelection helper), translate primitive ids back
@@ -419,6 +424,13 @@ export function CanvasPanel(): JSX.Element {
     if (newlyLocked.size > 0) {
       const ids = [...newlyLocked];
       useEditLockStore.getState().addLocks(ids);
+      // Freeze the user's post-edit element array as the new "previous
+      // frame" baseline. Without this, the next MCP snapshot would
+      // reconcile against the pre-edit geometry and the lockedIds branch
+      // would spring the box back to its pre-drag position.
+      prevReconciledElementsRef.current = elements.map(
+        (el) => ({ ...el }) as unknown as ExcalidrawElement,
+      );
       if (client !== null) {
         void client.postEditLock(ids, true).catch((err: unknown) => {
           // eslint-disable-next-line no-console

--- a/packages/app/src/store/chatStore.ts
+++ b/packages/app/src/store/chatStore.ts
@@ -6,6 +6,7 @@
 // StatusBar render. Tauri events land in `handleEvent`, which produces
 // immutable updates. Components read via selector hooks.
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import {
   cancelChat,
   fileToContentBlocks,
@@ -17,6 +18,16 @@ import {
   type RateLimitInfo,
   type UserContentBlock,
 } from '../services/chat.js';
+
+// Chat history survives app restarts via localStorage. Scene state is
+// already persisted by the MCP server; without this the canvas would
+// come back populated while the chat pane showed empty, which reads as
+// "the app lost my conversation" (B5).
+//
+// Cap the persisted list so long-running sessions don't blow past the
+// ~5MB localStorage quota. 200 bubbles ≈ well under the limit for pure
+// text; image attachments are a known cliff we haven't solved yet.
+const MAX_PERSISTED_MESSAGES = 200;
 
 function nanoId(): string {
   // Cheap client-side id. Good enough to key React lists; we don't send
@@ -99,7 +110,9 @@ export interface ChatState {
 
 const EMPTY_DRAFT: ChatDraft = { text: '', attachments: [] };
 
-export const useChatStore = create<ChatState>((set, get) => ({
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set, get) => ({
   messages: [],
   draft: { ...EMPTY_DRAFT },
   sessionId: null,
@@ -345,7 +358,35 @@ export const useChatStore = create<ChatState>((set, get) => ({
       ready: false,
     });
   },
-}));
+    }),
+    {
+      name: 'drawcast-chat',
+      storage: createJSONStorage(() => localStorage),
+      version: 1,
+      // Only the durable slice is persisted. The composer draft belongs to
+      // the live session; runtime flags (isStreaming, ready, rateLimit,
+      // lastError) must not leak across restarts or the UI comes back
+      // mid-stream with no actual child process running.
+      partialize: (s) => ({
+        messages: s.messages.slice(-MAX_PERSISTED_MESSAGES),
+        sessionId: s.sessionId,
+        model: s.model,
+        apiKeySource: s.apiKeySource,
+        mcpServers: s.mcpServers,
+        lastCostUsd: s.lastCostUsd,
+        lastUsage: s.lastUsage,
+      }),
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        state.isStreaming = false;
+        state.ready = false;
+        state.rateLimit = null;
+        state.lastError = null;
+        state.draft = { ...EMPTY_DRAFT };
+      },
+    },
+  ),
+);
 
 /**
  * Merge incoming assistant content blocks into the existing list.

--- a/packages/app/test/chatStore.persist.test.ts
+++ b/packages/app/test/chatStore.persist.test.ts
@@ -1,0 +1,98 @@
+// ChatStore persistence tests.
+//
+// Scene data already survives restarts thanks to the MCP-server sidecar;
+// chat messages didn't, which made a fresh launch look like the scene had
+// "lost its conversation". These cases lock in that messages round-trip
+// through localStorage and that volatile runtime flags (isStreaming,
+// ready, rateLimit, lastError) are NOT kept across sessions.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function freshChatStoreModule(): Promise<
+  typeof import('../src/store/chatStore.js')
+> {
+  vi.resetModules();
+  return await import('../src/store/chatStore.js');
+}
+
+describe('chatStore — persistence (B5)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('writes messages to localStorage under the drawcast-chat key', async () => {
+    const { useChatStore } = await freshChatStoreModule();
+    useChatStore.setState({
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          content: [{ type: 'text', text: 'hi' }],
+          createdAt: 1,
+          isStreaming: false,
+        },
+      ],
+    });
+    const raw = localStorage.getItem('drawcast-chat');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as { state: { messages: unknown[] } };
+    expect(parsed.state.messages).toHaveLength(1);
+  });
+
+  it('rehydrates the message list from localStorage on a fresh module load', async () => {
+    localStorage.setItem(
+      'drawcast-chat',
+      JSON.stringify({
+        state: {
+          messages: [
+            {
+              id: 'm1',
+              role: 'user',
+              content: [{ type: 'text', text: 'hello' }],
+              createdAt: 1,
+              isStreaming: false,
+            },
+          ],
+          sessionId: 'session-abc',
+        },
+        version: 1,
+      }),
+    );
+    const { useChatStore } = await freshChatStoreModule();
+    expect(useChatStore.getState().messages).toHaveLength(1);
+    expect(useChatStore.getState().messages[0]?.id).toBe('m1');
+    expect(useChatStore.getState().sessionId).toBe('session-abc');
+  });
+
+  it('resets volatile runtime flags on rehydrate (isStreaming, ready, lastError, rateLimit)', async () => {
+    localStorage.setItem(
+      'drawcast-chat',
+      JSON.stringify({
+        state: {
+          messages: [],
+          sessionId: 's1',
+          isStreaming: true,
+          ready: true,
+          lastError: 'boom',
+          rateLimit: { some: 'info' },
+        },
+        version: 1,
+      }),
+    );
+    const { useChatStore } = await freshChatStoreModule();
+    const s = useChatStore.getState();
+    expect(s.isStreaming).toBe(false);
+    expect(s.ready).toBe(false);
+    expect(s.lastError).toBeNull();
+    expect(s.rateLimit).toBeNull();
+  });
+
+  it('keeps the draft out of the persisted payload', async () => {
+    const { useChatStore } = await freshChatStoreModule();
+    useChatStore.getState().setDraftText('scratch text');
+    const raw = localStorage.getItem('drawcast-chat');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as { state: Record<string, unknown> };
+    expect(parsed.state.draft).toBeUndefined();
+  });
+});

--- a/packages/app/test/edit-lock.test.tsx
+++ b/packages/app/test/edit-lock.test.tsx
@@ -130,6 +130,66 @@ describe('edit-lock detection', () => {
     expect(useEditLockStore.getState().lockedIds.has('p-login')).toBe(true);
   });
 
+  it('preserves locally-edited geometry when a fresh MCP snapshot arrives', async () => {
+    // B4 integration: once a primitive is lock-flagged, the next scene
+    // push from the server must NOT overwrite what the user just dragged.
+    const { client } = createFakeClient();
+    renderWithMcp(client);
+
+    await act(async () => {
+      useSceneStore.getState().setSnapshot({
+        primitives: [primitive],
+        theme: 'sketchy',
+        selection: [],
+        locked: [],
+      });
+    });
+
+    const mock = getExcalidrawMock();
+    const initialRendered = (mock.lastElements as ReadonlyArray<{
+      id: string;
+      type: string;
+      x: number;
+      y: number;
+      version: number;
+      customData?: { drawcastPrimitiveId?: string };
+    }>).map((el) => ({ ...el }));
+    const rect = initialRendered.find((el) => el.type === 'rectangle')!;
+    expect(rect).toBeDefined();
+
+    // Simulate a drag: rectangle version bumps + moves +200,+150.
+    const movedRect = { ...rect, x: rect.x + 200, y: rect.y + 150, version: rect.version + 2 };
+    const mutated = initialRendered.map((el) =>
+      el.id === rect.id ? movedRect : el,
+    );
+
+    await act(async () => {
+      mock.onChange?.(mutated, { selectedElementIds: {} });
+    });
+    expect(useEditLockStore.getState().lockedIds.has('p-login')).toBe(true);
+
+    // Server pushes the same primitive again — compiling would place it
+    // back at the origin. The reconciler must keep the dragged geometry.
+    await act(async () => {
+      useSceneStore.getState().setSnapshot({
+        primitives: [primitive],
+        theme: 'sketchy',
+        selection: [],
+        locked: ['p-login'],
+      });
+    });
+
+    const afterSnapshot = mock.lastElements as ReadonlyArray<{
+      id: string;
+      type: string;
+      x: number;
+      y: number;
+    }>;
+    const rectAfter = afterSnapshot.find((el) => el.type === 'rectangle')!;
+    expect(rectAfter.x).toBe(movedRect.x);
+    expect(rectAfter.y).toBe(movedRect.y);
+  });
+
   it('does NOT post editLock when onChange echoes the rendered versions', async () => {
     const { client, editLockCalls } = createFakeClient();
     renderWithMcp(client);

--- a/packages/app/test/reconcile.test.ts
+++ b/packages/app/test/reconcile.test.ts
@@ -98,4 +98,77 @@ describe('reconcileElements', () => {
     // p2 is new — keeps the fresh id.
     expect(result.elements[1]!.id).toBe('brand-new');
   });
+
+  // B4: once a primitive is edit-locked by the user, later MCP snapshots
+  // must NOT trample its local geometry. The reconciler is where that
+  // preference is enforced — it has both the prior rendered element
+  // (the user's edited state) and the fresh compile, and returns the
+  // prior object verbatim whenever the primitive id is in the lock set.
+  it('keeps the full prior element for locked primitives (geometry + identity)', () => {
+    const prev = [
+      make('b1', 'rectangle', {
+        id: 'stable-id',
+        x: 500,
+        y: 500,
+        width: 120,
+        height: 60,
+        version: 7,
+      }),
+    ];
+    const fresh = [
+      make('b1', 'rectangle', {
+        id: 'fresh-id',
+        x: 100,
+        y: 100,
+        width: 80,
+        height: 40,
+        version: 1,
+      }),
+    ];
+    const result = reconcileElements({
+      prev,
+      fresh,
+      files: {},
+      lockedIds: new Set(['b1']),
+    });
+    const el = result.elements[0]!;
+    expect(el.id).toBe('stable-id');
+    expect(el.x).toBe(500);
+    expect(el.y).toBe(500);
+    expect(el.width).toBe(120);
+    expect(el.height).toBe(60);
+    expect(el.version).toBe(7);
+  });
+
+  it('unlocked primitive adopts fresh geometry but keeps the stable id', () => {
+    const prev = [
+      make('b1', 'rectangle', { id: 'stable-id', x: 500, y: 500, version: 7 }),
+    ];
+    const fresh = [
+      make('b1', 'rectangle', { id: 'fresh-id', x: 100, y: 100, version: 1 }),
+    ];
+    const result = reconcileElements({
+      prev,
+      fresh,
+      files: {},
+      lockedIds: new Set(),
+    });
+    const el = result.elements[0]!;
+    expect(el.id).toBe('stable-id');
+    expect(el.x).toBe(100);
+    expect(el.y).toBe(100);
+    expect(el.version).toBe(7);
+  });
+
+  it('lockedIds is optional — omitted means "none locked"', () => {
+    const prev = [
+      make('b1', 'rectangle', { id: 'stable-id', x: 500, y: 500 }),
+    ];
+    const fresh = [
+      make('b1', 'rectangle', { id: 'fresh-id', x: 100, y: 100 }),
+    ];
+    const result = reconcileElements({ prev, fresh, files: {} });
+    expect(result.elements[0]!.x).toBe(100);
+    expect(result.elements[0]!.y).toBe(100);
+  });
 });

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -40,14 +40,43 @@ function isPoint(ref: PrimitiveId | Point): ref is Point {
   return typeof ref !== 'string';
 }
 
-function resolveEndpoint(
+/**
+ * Ray from the record's centre towards `towards` intersected with the
+ * record's axis-aligned bbox. Used so arrow endpoints land on the near
+ * edge of a bindable shape rather than its centre — matches Excalidraw's
+ * native "connect two shapes" visual behaviour. Excalidraw's binding
+ * still owns re-anchoring during drag; this only fixes the initial paint.
+ */
+function boundaryPoint(record: PrimitiveRecord, towards: Point): Point {
+  const cx = record.bbox.x + record.bbox.w / 2;
+  const cy = record.bbox.y + record.bbox.h / 2;
+  const dx = towards[0] - cx;
+  const dy = towards[1] - cy;
+  const absDx = Math.abs(dx);
+  const absDy = Math.abs(dy);
+  if (absDx < 1e-6 && absDy < 1e-6) return [cx, cy];
+  const halfW = record.bbox.w / 2;
+  const halfH = record.bbox.h / 2;
+  const tx = absDx > 1e-6 ? halfW / absDx : Number.POSITIVE_INFINITY;
+  const ty = absDy > 1e-6 ? halfH / absDy : Number.POSITIVE_INFINITY;
+  const t = Math.min(tx, ty);
+  return [cx + dx * t, cy + dy * t];
+}
+
+interface ResolvedEndpointCenter {
+  center: Point;
+  /** Non-null only when the endpoint references a bindable primitive. */
+  record: PrimitiveRecord | null;
+}
+
+function resolveCenter(
   ref: PrimitiveId | Point,
   ctx: CompileContext,
   primitiveId: PrimitiveId,
   role: 'from' | 'to',
-): Point {
+): ResolvedEndpointCenter {
   if (isPoint(ref)) {
-    return [ref[0], ref[1]];
+    return { center: [ref[0], ref[1]], record: null };
   }
   const record = ctx.getRecord(ref);
   if (!record) {
@@ -56,9 +85,9 @@ function resolveEndpoint(
       message: `Connector ${primitiveId}.${role} references unknown primitive '${String(ref)}'.`,
       primitiveId,
     });
-    return [0, 0];
+    return { center: [0, 0], record: null };
   }
-  return centerOfRecord(record);
+  return { center: centerOfRecord(record), record };
 }
 
 function buildRawPoints(
@@ -139,9 +168,18 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
   const routing = p.routing ?? 'straight';
   const isElbow = routing === 'elbow';
 
-  // 1) Endpoints -> raw scene-coordinate points
-  const start = resolveEndpoint(p.from, ctx, p.id, 'from');
-  const end = resolveEndpoint(p.to, ctx, p.id, 'to');
+  // 1) Endpoints -> raw scene-coordinate points. Each endpoint that is a
+  //    reference to a bindable shape is anchored to the bbox edge nearest
+  //    the opposite endpoint, so the arrow starts/ends on the shape's
+  //    boundary rather than through its centre.
+  const fromRes = resolveCenter(p.from, ctx, p.id, 'from');
+  const toRes = resolveCenter(p.to, ctx, p.id, 'to');
+  const start = fromRes.record
+    ? boundaryPoint(fromRes.record, toRes.center)
+    : fromRes.center;
+  const end = toRes.record
+    ? boundaryPoint(toRes.record, fromRes.center)
+    : toRes.center;
   const rawPoints = buildRawPoints(start, end, routing);
   const { points, width, height } = normalizePoints(rawPoints);
 

--- a/packages/core/src/emit/labelBox.ts
+++ b/packages/core/src/emit/labelBox.ts
@@ -125,19 +125,18 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
       fontSize,
       fontFamily,
     });
-    const wrappedMetrics = measureText({
-      text: wrapped,
-      fontSize,
-      fontFamily,
-    });
 
     textId = newElementId();
+    // Excalidraw requires container-bound text to share the container's bbox;
+    // the renderer itself places the glyph run according to textAlign /
+    // verticalAlign. Emitting a smaller glyph-measured bbox makes the label
+    // clip or disappear (the B1 bug).
     const textBase = baseElementFields({
       id: textId,
-      x: p.at[0] - wrappedMetrics.width / 2,
-      y: p.at[1] - wrappedMetrics.height / 2,
-      width: wrappedMetrics.width,
-      height: wrappedMetrics.height,
+      x: commonBase.x,
+      y: commonBase.y,
+      width,
+      height,
       angle: 0 as Radians,
       strokeColor: style.strokeColor,
       backgroundColor: 'transparent',

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -91,11 +91,12 @@ export const sketchyTheme = {
   nodes: {
     default: {
       strokeColor: '#1e1e1e',
-      backgroundColor: '#ffffff',
+      backgroundColor: '#fef3c7',
       fillStyle: 'solid',
       strokeWidth: 2,
       strokeStyle: 'solid',
       roughness: 1,
+      roundness: 3,
     },
     terminal: {
       shape: 'ellipse',
@@ -195,12 +196,13 @@ export const cleanTheme = {
   },
   nodes: {
     default: {
-      strokeColor: '#1e1e1e',
-      backgroundColor: '#ffffff',
+      strokeColor: '#1e40af',
+      backgroundColor: '#e0f2fe',
       fillStyle: 'solid',
       strokeWidth: 2,
       strokeStyle: 'solid',
       roughness: 0,
+      roundness: 3,
     },
     terminal: {
       shape: 'ellipse',
@@ -301,11 +303,12 @@ export const monoTheme = {
   nodes: {
     default: {
       strokeColor: '#1e1e1e',
-      backgroundColor: '#ffffff',
+      backgroundColor: '#f1f3f5',
       fillStyle: 'hachure',
       strokeWidth: 2,
       strokeStyle: 'solid',
       roughness: 1,
+      roundness: 3,
     },
     terminal: {
       shape: 'ellipse',

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -1,0 +1,178 @@
+// Connector endpoint-anchoring regression tests.
+//
+// Without this guard the emitter put arrow endpoints at the shape centres,
+// which visually reads as "the arrow pierces the box". The emitter now
+// intersects the ray between the two centres with each source/target
+// bounding box, so the arrow starts on the near edge and ends on the far
+// edge — matching user expectation and Excalidraw's own "connect two
+// shapes" behaviour. Bindings are retained so Excalidraw still auto-
+// re-anchors on drag.
+
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/compile/index.js';
+import { sketchyTheme } from '../src/theme.js';
+import type {
+  Connector,
+  LabelBox,
+  Primitive,
+  PrimitiveId,
+  Scene,
+} from '../src/primitives.js';
+import type {
+  ExcalidrawArrowElement,
+  ExcalidrawRectangleElement,
+} from '../src/types/excalidraw.js';
+
+function makeScene(primitives: Primitive[]): Scene {
+  return {
+    primitives: new Map(primitives.map((p) => [p.id, p])),
+    theme: sketchyTheme,
+  };
+}
+
+function findArrow(
+  elements: readonly {
+    type: string;
+  }[],
+): ExcalidrawArrowElement {
+  return elements.find(
+    (e): e is ExcalidrawArrowElement => e.type === 'arrow',
+  ) as ExcalidrawArrowElement;
+}
+
+describe('emitConnector — boundary anchoring (B3)', () => {
+  it('horizontal pair: arrow starts at source right edge, ends at target left edge', () => {
+    // A centred at (100,100), fixed 80x40 → right edge x = 140
+    // B centred at (300,100), fixed 80x40 → left  edge x = 260
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'straight',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    // arrow.x (= start absolute x) should hug A's right edge, not its centre.
+    expect(arrow.x).toBeGreaterThan(135);
+    expect(arrow.x).toBeLessThanOrEqual(141);
+
+    // End absolute x = arrow.x + last point dx should hug B's left edge.
+    const lastPoint = arrow.points[arrow.points.length - 1]!;
+    const endX = arrow.x + lastPoint[0];
+    expect(endX).toBeGreaterThanOrEqual(259);
+    expect(endX).toBeLessThan(265);
+  });
+
+  it('vertical pair: arrow starts at source bottom edge, ends at target top edge', () => {
+    // A (100,100) 80x40 → bottom edge y = 120
+    // B (100,300) 80x40 → top    edge y = 280
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 300],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'straight',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    expect(arrow.y).toBeGreaterThan(115);
+    expect(arrow.y).toBeLessThanOrEqual(121);
+
+    const lastPoint = arrow.points[arrow.points.length - 1]!;
+    const endY = arrow.y + lastPoint[1];
+    expect(endY).toBeGreaterThanOrEqual(279);
+    expect(endY).toBeLessThan(285);
+  });
+
+  it('keeps startBinding / endBinding so Excalidraw still auto-re-anchors', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+    const rects = result.elements.filter(
+      (el): el is ExcalidrawRectangleElement => el.type === 'rectangle',
+    );
+    expect(arrow.startBinding?.elementId).toBe(rects[0]!.id);
+    expect(arrow.endBinding?.elementId).toBe(rects[1]!.id);
+  });
+
+  it('raw Point endpoints are passed through unchanged (no boundary math)', () => {
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: [10, 20],
+      to: [110, 220],
+      routing: 'straight',
+    };
+    const result = compile(makeScene([c]));
+    const arrow = findArrow(result.elements);
+    expect(arrow.x).toBe(10);
+    expect(arrow.y).toBe(20);
+    const lastPoint = arrow.points[arrow.points.length - 1]!;
+    expect(arrow.x + lastPoint[0]).toBe(110);
+    expect(arrow.y + lastPoint[1]).toBe(220);
+    expect(arrow.startBinding).toBeNull();
+    expect(arrow.endBinding).toBeNull();
+  });
+});

--- a/packages/core/test/emit-labelBox.test.ts
+++ b/packages/core/test/emit-labelBox.test.ts
@@ -1,0 +1,116 @@
+// LabelBox geometry regression tests.
+//
+// Excalidraw's container-bound text renders correctly only when the text
+// element shares the container's bounding box (x, y, width, height); the
+// renderer itself positions the glyph run according to textAlign /
+// verticalAlign. Emitting the text with the measured glyph bbox instead of
+// the container bbox causes the label to either clip or disappear — which
+// is the user-visible B1 bug this file guards against.
+
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/compile/index.js';
+import { sketchyTheme } from '../src/theme.js';
+import type {
+  LabelBox,
+  PrimitiveId,
+  Scene,
+} from '../src/primitives.js';
+import type {
+  ExcalidrawRectangleElement,
+  ExcalidrawTextElement,
+} from '../src/types/excalidraw.js';
+
+function makeScene(primitives: LabelBox[]): Scene {
+  return {
+    primitives: new Map(primitives.map((p) => [p.id, p])),
+    theme: sketchyTheme,
+  };
+}
+
+describe('emitLabelBox — container-bound text geometry (B1)', () => {
+  it('text element shares the container bbox so Excalidraw renders it', () => {
+    const p: LabelBox = {
+      kind: 'labelBox',
+      id: 'n1' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      text: 'Hello',
+    };
+    const result = compile(makeScene([p]));
+    const shape = result.elements.find(
+      (e): e is ExcalidrawRectangleElement => e.type === 'rectangle',
+    )!;
+    const text = result.elements.find(
+      (e): e is ExcalidrawTextElement => e.type === 'text',
+    )!;
+
+    expect(text.containerId).toBe(shape.id);
+    expect(text.x).toBe(shape.x);
+    expect(text.y).toBe(shape.y);
+    expect(text.width).toBe(shape.width);
+    expect(text.height).toBe(shape.height);
+    expect(text.autoResize).toBe(false);
+  });
+
+  it('preserves originalText verbatim and emits wrapped glyph run', () => {
+    const p: LabelBox = {
+      kind: 'labelBox',
+      id: 'n1' as PrimitiveId,
+      shape: 'rectangle',
+      at: [0, 0],
+      text: 'Hello World',
+    };
+    const result = compile(makeScene([p]));
+    const text = result.elements.find(
+      (e): e is ExcalidrawTextElement => e.type === 'text',
+    )!;
+
+    expect(text.originalText).toBe('Hello World');
+    expect(text.text.length).toBeGreaterThan(0);
+    expect(text.text).toMatch(/Hello/);
+  });
+
+  it('fixed-size box still places text at the container bbox', () => {
+    const p: LabelBox = {
+      kind: 'labelBox',
+      id: 'n1' as PrimitiveId,
+      shape: 'rectangle',
+      at: [0, 0],
+      fit: 'fixed',
+      size: [120, 80],
+      text: 'multi line label that probably wraps',
+    };
+    const result = compile(makeScene([p]));
+    const shape = result.elements.find(
+      (e): e is ExcalidrawRectangleElement => e.type === 'rectangle',
+    )!;
+    const text = result.elements.find(
+      (e): e is ExcalidrawTextElement => e.type === 'text',
+    )!;
+
+    expect(shape.width).toBe(120);
+    expect(shape.height).toBe(80);
+    expect(text.x).toBe(shape.x);
+    expect(text.y).toBe(shape.y);
+    expect(text.width).toBe(120);
+    expect(text.height).toBe(80);
+  });
+
+  it('shape still registers the text in boundElements so Excalidraw pairs them', () => {
+    const p: LabelBox = {
+      kind: 'labelBox',
+      id: 'n1' as PrimitiveId,
+      shape: 'rectangle',
+      at: [0, 0],
+      text: 'X',
+    };
+    const result = compile(makeScene([p]));
+    const shape = result.elements.find(
+      (e): e is ExcalidrawRectangleElement => e.type === 'rectangle',
+    )!;
+    const text = result.elements.find(
+      (e): e is ExcalidrawTextElement => e.type === 'text',
+    )!;
+    expect(shape.boundElements).toContainEqual({ type: 'text', id: text.id });
+  });
+});

--- a/packages/core/test/theme-defaults.test.ts
+++ b/packages/core/test/theme-defaults.test.ts
@@ -1,0 +1,43 @@
+// Built-in theme defaults.
+//
+// `nodes.default` is what every un-styled LabelBox falls back to, so it has
+// to look like something — not bare white-on-black. Clean and mono lean on
+// soft pastels + rounded corners, sketchy leans on hand-drawn roughness
+// with a warm fill. These expectations are intentionally shallow: they
+// encode "non-sterile" intent without pinning exact hex codes, so a future
+// designer can retune without rewriting the test.
+
+import { describe, expect, it } from 'vitest';
+import { cleanTheme, monoTheme, sketchyTheme } from '../src/theme.js';
+
+describe('built-in theme nodes.default (B2)', () => {
+  it('clean default uses a tinted fill and rounded corners', () => {
+    const def = cleanTheme.nodes.default;
+    expect(def.backgroundColor).not.toBe('#ffffff');
+    expect(def.backgroundColor).not.toBe('transparent');
+    expect(def.roundness).toBeDefined();
+    expect(def.roundness).not.toBeNull();
+    expect(def.fillStyle).toBe('solid');
+  });
+
+  it('sketchy default keeps roughness ≥ 1 and a warm tinted fill', () => {
+    const def = sketchyTheme.nodes.default;
+    expect(def.roughness).toBeGreaterThanOrEqual(1);
+    expect(def.backgroundColor).not.toBe('#ffffff');
+    expect(def.backgroundColor).not.toBe('transparent');
+  });
+
+  it('mono default uses an off-white fill with rounded corners', () => {
+    const def = monoTheme.nodes.default;
+    expect(def.backgroundColor).not.toBe('#ffffff');
+    expect(def.backgroundColor).not.toBe('transparent');
+    expect(def.roundness).toBeDefined();
+    expect(def.roundness).not.toBeNull();
+  });
+
+  it('edge defaults are not pure black so lines read against the stroke colour', () => {
+    expect(cleanTheme.edges.default.strokeColor).not.toBe('#000000');
+    expect(sketchyTheme.edges.default.strokeColor).not.toBe('#000000');
+    expect(monoTheme.edges.default.strokeColor).not.toBe('#000000');
+  });
+});


### PR DESCRIPTION
## Summary

The user reported that AI-generated flowcharts were visibly broken. Five independent bugs, each fixed via Red→Green TDD with a dedicated commit.

| Commit | Bug | Fix |
|---|---|---|
| f93e1d5 | Labels invisible on every box | `emitLabelBox` now puts the container-bound text element at the container's bbox; Excalidraw needs that to render |
| f05a245 | Arrows pierced the centre of boxes | Connector endpoints intersect the centre-to-centre ray with each bbox, so they land on the near edge |
| 896ca0f | Nodes looked sterile (white on black, square corners) | Built-in theme `nodes.default` gets a tinted fill + rounded corners for `sketchy` / `clean` / `mono` |
| aa47f62 | User drags/deletes were overwritten by the next MCP snapshot | `reconcileElements` takes a `lockedIds` set and returns the prior element verbatim; `CanvasPanel` snapshots post-edit elements as the next baseline |
| ca3f013 | Chat history vanished on restart (scene survived) | `chatStore` wrapped in zustand `persist` (localStorage, `drawcast-chat`) with volatile runtime flags reset on rehydrate |

## Test plan

- [x] `pnpm turbo run test` — 6/6 tasks pass (core 70 / app 53 / mcp-server)
- [x] `pnpm turbo run typecheck build` — 6/6 tasks pass
- [x] `pnpm turbo run lint` — 3/3 tasks pass
- [x] Red step for every bug produced the expected failure before the Green implementation landed
- [ ] Manual smoke via `pnpm tauri dev`:
  - [ ] Ask Claude for a labelled box → text is visible inside the box
  - [ ] `draw_set_theme sketchy|clean|mono` → nodes carry the matching fill + corner radius
  - [ ] Two-box + arrow prompt → arrow sits on the boxes' edges, not through the centre
  - [ ] Drag a box, then ask for another recompile → dragged position sticks; delete key removes the box and it stays gone after the next scene push
  - [ ] Quit and relaunch the app → chat history is restored

## Notes for the reviewer

- `packages/core/src/emit/labelBox.ts`: `wrappedMetrics` is now only used via `wrapText`'s wrapped string for the text content; its dimensions were the root of the B1 clipping.
- `packages/core/src/emit/connector.ts`: bindings still carry `focus: 0` / `gap: 1` so Excalidraw keeps auto-re-anchoring on drag; only the initial paint coordinate moves to the bbox edge.
- `packages/app/src/mcp/reconcile.ts`: `lockedIds` is optional — existing callers keep working unchanged.
- `packages/app/src/panels/CanvasPanel.tsx`: `prevReconciledElementsRef` is refreshed from `onChange` elements when a lock fires. Without that, the next reconcile would still see pre-drag geometry in `prev` and the lock branch would spring the box back.
- `packages/app/src/store/chatStore.ts`: `partialize` excludes `isStreaming`, `ready`, `rateLimit`, `lastError`, `draft`; `onRehydrateStorage` resets them so the UI doesn't come back mid-stream. 200-message cap guards localStorage quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)