### PR TITLE
fix: align Excalidraw emit with 0.17.6 schema + harden chat UI

### DIFF
--- a/packages/app/src/panels/ChatPanel.tsx
+++ b/packages/app/src/panels/ChatPanel.tsx
@@ -13,6 +13,7 @@ import {
   AssistantRuntimeProvider,
   MessagePrimitive,
   ThreadPrimitive,
+  type EmptyMessagePartComponent,
 } from '@assistant-ui/react';
 import {
   useCallback,
@@ -31,6 +32,7 @@ import { saveUploads } from '../services/uploads.js';
 import { useChatStore, type Attachment } from '../store/chatStore.js';
 import { useToastStore } from '../store/toastStore.js';
 import { ToolCallUI } from './chat/ToolCallUI.js';
+import { ReasoningUI } from './chat/ReasoningUI.js';
 import { useDrawcastRuntime } from './chat/runtime.js';
 
 export function ChatPanel(): JSX.Element {
@@ -147,6 +149,7 @@ function AssistantMessage(): JSX.Element {
       <MessagePrimitive.Parts
         components={{
           Text: TextPart,
+          Reasoning: ReasoningUI,
           Image: ImagePart,
           File: FilePartAssistant,
           Empty: StreamingCursor,
@@ -189,7 +192,8 @@ function FilePartAssistant({ mimeType }: { mimeType: string }): JSX.Element {
   );
 }
 
-function StreamingCursor(): JSX.Element {
+const StreamingCursor: EmptyMessagePartComponent = ({ status }) => {
+  if (status.type !== 'running') return null;
   return (
     <span
       aria-label="streaming"
@@ -198,7 +202,7 @@ function StreamingCursor(): JSX.Element {
       ▍
     </span>
   );
-}
+};
 
 // -----------------------------------------------------------------------------
 // Composer — text input + attachment chips + send. Also owns the drag-drop

--- a/packages/app/src/panels/chat/ReasoningUI.tsx
+++ b/packages/app/src/panels/chat/ReasoningUI.tsx
@@ -1,0 +1,50 @@
+// Collapsible card for extended-thinking (reasoning) message parts.
+// Shape mirrors ToolCallUI so the two stack visually in a thread: same
+// border, same chevron, same density. Defaults to collapsed because the
+// reasoning block can be long and most users only want it on demand.
+//
+// Interaction model: React state-driven toggle. Earlier revisions used a
+// native <details>, but assistant-ui re-renders message parts on every
+// streaming tick and that re-application was resetting the open flag,
+// making the card look like it never toggled. Explicit state avoids it.
+import { useState } from 'react';
+import type { ReasoningMessagePartComponent } from '@assistant-ui/react';
+
+export const ReasoningUI: ReasoningMessagePartComponent = ({ text }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      data-testid="dc-reasoning-card"
+      data-open={open ? 'true' : 'false'}
+      className="mt-dc-xs overflow-hidden rounded-dc-sm border border-dc-border-hairline bg-dc-bg-app/50"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-center gap-dc-xs px-dc-sm py-dc-xs text-left text-[12px] text-dc-text-secondary select-none"
+      >
+        <span
+          aria-hidden
+          className="text-dc-text-tertiary transition-transform"
+          style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}
+        >
+          ▸
+        </span>
+        <span aria-hidden>💭</span>
+        <span className="font-mono text-dc-text-primary">Thinking</span>
+        <span className="ml-auto font-mono text-[11px] text-dc-text-tertiary">
+          {text.length > 0 ? `${text.length} chars` : '…'}
+        </span>
+      </button>
+      {open && (
+        <div className="border-t border-dc-border-hairline px-dc-sm py-dc-xs">
+          <pre className="dc-scrollbar max-h-80 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-dc-text-secondary">
+            {text}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/app/src/panels/chat/ToolCallUI.tsx
+++ b/packages/app/src/panels/chat/ToolCallUI.tsx
@@ -2,13 +2,19 @@
 // `tools.Fallback` in MessagePrimitive.Parts so *every* tool Claude
 // invokes — Bash, Read, mcp__drawcast__*, etc. — renders the same way.
 //
-// Interaction model: native <details>. No extra state, no effect loops,
-// and keyboard/screen-reader accessibility is free.
+// Interaction model: React state-driven toggle. A prior revision used a
+// native <details>, but assistant-ui re-creates this component on every
+// streaming tick (new `status`, new `result` arriving) which wiped the
+// implicit `open` flag and made the card look uncollapsible. Explicit
+// open state is keyed by toolCallId so index-keyed part remounts do not
+// collapse the card immediately after a click.
+import { useCallback, useEffect, useState } from 'react';
 import type { ToolCallMessagePartComponent } from '@assistant-ui/react';
 
 // `mcp__{server}__{tool}` — double underscore on both sides of the
 // server slug. The tool part may itself contain underscores.
 const MCP_TOOL_PATTERN = /^mcp__([^_]+)__(.+)$/;
+const toolOpenById = new Map<string, boolean>();
 
 function splitName(name: string): { short: string; server: string | null } {
   const match = name.match(MCP_TOOL_PATTERN);
@@ -50,6 +56,7 @@ function formatResult(content: unknown): string {
 }
 
 export const ToolCallUI: ToolCallMessagePartComponent = ({
+  toolCallId,
   toolName,
   args,
   argsText,
@@ -57,6 +64,20 @@ export const ToolCallUI: ToolCallMessagePartComponent = ({
   isError,
   status,
 }) => {
+  const [open, setOpen] = useState(() => toolOpenById.get(toolCallId) ?? false);
+
+  useEffect(() => {
+    setOpen(toolOpenById.get(toolCallId) ?? false);
+  }, [toolCallId]);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((value) => {
+      const next = !value;
+      toolOpenById.set(toolCallId, next);
+      return next;
+    });
+  }, [toolCallId]);
+
   const { short, server } = splitName(toolName);
   const hasResult = result !== undefined;
   const running = !hasResult && status?.type === 'running';
@@ -77,13 +98,23 @@ export const ToolCallUI: ToolCallMessagePartComponent = ({
   const resultText = hasResult ? formatResult(result) : '';
 
   return (
-    <details
+    <div
       data-testid="dc-tool-card"
       data-tool-status={indicator}
-      className={`group mt-dc-xs overflow-hidden rounded-dc-sm border ${borderCls} bg-dc-bg-app/60`}
+      data-open={open ? 'true' : 'false'}
+      className={`mt-dc-xs overflow-hidden rounded-dc-sm border ${borderCls} bg-dc-bg-app/60`}
     >
-      <summary className="flex cursor-pointer list-none items-center gap-dc-xs px-dc-sm py-dc-xs text-[12px] text-dc-text-secondary select-none [&::-webkit-details-marker]:hidden">
-        <span aria-hidden className="text-dc-text-tertiary transition-transform group-open:rotate-90">
+      <button
+        type="button"
+        onClick={toggleOpen}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-center gap-dc-xs px-dc-sm py-dc-xs text-left text-[12px] text-dc-text-secondary select-none"
+      >
+        <span
+          aria-hidden
+          className="text-dc-text-tertiary transition-transform"
+          style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}
+        >
           ▸
         </span>
         <span aria-hidden>🔧</span>
@@ -96,29 +127,31 @@ export const ToolCallUI: ToolCallMessagePartComponent = ({
         <span className={`ml-auto font-mono text-[13px] ${indicatorCls}`} aria-label={`tool ${indicator}`}>
           {indicatorGlyph}
         </span>
-      </summary>
-      <div className="border-t border-dc-border-hairline px-dc-sm py-dc-xs">
-        <p className="mb-dc-xs text-[10px] uppercase tracking-wide text-dc-text-tertiary">
-          Input
-        </p>
-        <pre className="dc-scrollbar max-h-60 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-dc-text-secondary">
-          {inputText}
-        </pre>
-        {hasResult && (
-          <div className="mt-dc-sm">
-            <p className="mb-dc-xs text-[10px] uppercase tracking-wide text-dc-text-tertiary">
-              Result
-            </p>
-            <pre
-              className={`dc-scrollbar max-h-60 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed ${
-                isError ? 'text-dc-status-danger' : 'text-dc-text-secondary'
-              }`}
-            >
-              {resultText.length > 0 ? resultText : '(empty)'}
-            </pre>
-          </div>
-        )}
-      </div>
-    </details>
+      </button>
+      {open && (
+        <div className="border-t border-dc-border-hairline px-dc-sm py-dc-xs">
+          <p className="mb-dc-xs text-[10px] uppercase tracking-wide text-dc-text-tertiary">
+            Input
+          </p>
+          <pre className="dc-scrollbar max-h-60 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-dc-text-secondary">
+            {inputText}
+          </pre>
+          {hasResult && (
+            <div className="mt-dc-sm">
+              <p className="mb-dc-xs text-[10px] uppercase tracking-wide text-dc-text-tertiary">
+                Result
+              </p>
+              <pre
+                className={`dc-scrollbar max-h-60 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed ${
+                  isError ? 'text-dc-status-danger' : 'text-dc-text-secondary'
+                }`}
+              >
+                {resultText.length > 0 ? resultText : '(empty)'}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 };

--- a/packages/app/src/panels/chat/runtime.ts
+++ b/packages/app/src/panels/chat/runtime.ts
@@ -12,6 +12,7 @@ import {
   type ExternalStoreAdapter,
   type ThreadMessageLike,
 } from '@assistant-ui/react';
+import { useMemo } from 'react';
 import {
   sendChat,
   type AssistantContentBlock,
@@ -66,7 +67,16 @@ function convertAssistantContent(
   const parts: ThreadContentPart[] = [];
   for (const b of blocks) {
     if (b.type === 'text') {
+      // Drop empty text blocks — Claude streams these around tool calls and
+      // they'd otherwise render as ghost bubbles (see the B1 empty-box bug).
+      if (b.text.length === 0) continue;
       parts.push({ type: 'text', text: b.text });
+      continue;
+    }
+    if (b.type === 'thinking') {
+      const text = b.thinking ?? '';
+      if (text.length === 0) continue;
+      parts.push({ type: 'reasoning', text });
       continue;
     }
     if (b.type === 'tool_use') {
@@ -219,19 +229,48 @@ async function fallbackOnNew(message: AppendMessage): Promise<void> {
   }
 }
 
+/**
+ * True if this assistant message has at least one render-worthy content
+ * block. Claude emits empty assistant snapshots around tool calls that
+ * would otherwise render as ghost bubbles. Filtering at the adapter level
+ * is simpler than juggling empty-part rendering inside assistant-ui's
+ * message primitive.
+ */
+function assistantMessageHasRenderableContent(m: ChatMessage): boolean {
+  if (m.role !== 'assistant') return true;
+  const blocks = m.content as AssistantContentBlock[];
+  for (const b of blocks) {
+    if (b.type === 'text' && b.text.trim().length > 0) return true;
+    if (b.type === 'thinking' && (b.thinking ?? '').trim().length > 0) return true;
+    if (b.type === 'tool_use') return true;
+    if (b.type === 'tool_result') return true;
+  }
+  return false;
+}
+
 export function useDrawcastRuntime() {
-  const messages = useChatStore((s) => s.messages);
+  const rawMessages = useChatStore((s) => s.messages);
   const isRunning = useChatStore((s) => s.isStreaming);
 
-  const adapter: ExternalStoreAdapter<ChatMessage> = {
-    messages,
-    isRunning,
-    convertMessage,
-    onNew: fallbackOnNew,
-    onCancel: async () => {
-      await useChatStore.getState().cancelTurn();
-    },
-  };
+  const messages = useMemo(
+    () => rawMessages.filter(assistantMessageHasRenderableContent),
+    [rawMessages],
+  );
+  const lastMessage = messages[messages.length - 1];
+  const runtimeIsRunning = isRunning && lastMessage?.role === 'assistant';
+
+  const adapter = useMemo<ExternalStoreAdapter<ChatMessage>>(
+    () => ({
+      messages,
+      isRunning: runtimeIsRunning,
+      convertMessage,
+      onNew: fallbackOnNew,
+      onCancel: async () => {
+        await useChatStore.getState().cancelTurn();
+      },
+    }),
+    [messages, runtimeIsRunning],
+  );
 
   return useExternalStoreRuntime(adapter);
 }

--- a/packages/app/src/services/chat.ts
+++ b/packages/app/src/services/chat.ts
@@ -21,6 +21,11 @@ export type UserContentBlock =
 
 export type AssistantContentBlock =
   | { type: 'text'; text: string }
+  // Extended thinking. Claude emits these when `-a thinking` or the managed
+  // agent default is on; we surface them as collapsed "reasoning" parts so
+  // the user sees Claude's chain-of-thought without it hijacking the
+  // transcript layout.
+  | { type: 'thinking'; thinking: string; signature?: string }
   | { type: 'tool_use'; id: string; name: string; input: unknown }
   | {
       type: 'tool_result';

--- a/packages/app/src/store/chatStore.ts
+++ b/packages/app/src/store/chatStore.ts
@@ -251,7 +251,9 @@ export const useChatStore = create<ChatState>()(
     if (ev.type === 'assistant') {
       const assistantEv = ev as Extract<ChatEvent, { type: 'assistant' }>;
       const uuid = typeof assistantEv.uuid === 'string' ? assistantEv.uuid : undefined;
-      const incoming = (assistantEv.message?.content ?? []) as AssistantContentBlock[];
+      const incoming = normalizeAssistantContent(
+        (assistantEv.message?.content ?? []) as AssistantContentBlock[],
+      );
       set((s) => {
         const existingIdx =
           uuid === undefined
@@ -259,6 +261,7 @@ export const useChatStore = create<ChatState>()(
             : s.messages.findIndex(
                 (m) => m.role === 'assistant' && m.turnUuid === uuid,
               );
+        if (incoming.length === 0) return s;
         if (existingIdx >= 0) {
           const updated = [...s.messages];
           updated[existingIdx] = {
@@ -403,4 +406,14 @@ function mergeAssistantContent(
   next: AssistantContentBlock[],
 ): AssistantContentBlock[] {
   return [...next];
+}
+
+function normalizeAssistantContent(
+  blocks: AssistantContentBlock[],
+): AssistantContentBlock[] {
+  return blocks.filter((b) => {
+    if (b.type === 'text') return b.text.trim().length > 0;
+    if (b.type === 'thinking') return (b.thinking ?? '').trim().length > 0;
+    return true;
+  });
 }

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -5,8 +5,12 @@
 //   P3  — points[0] must be [0,0] after normalisation; (x,y) captures the
 //         pre-normalisation start point
 //   P13 — at least 2 points always
-//   P17 — elbow arrows use FixedPointBinding with fixedPoint [0.4999, 0.5001]
 //   P18 — orphan references degrade to a free arrow with a warning
+//
+// Excalidraw 0.17.x baseline: no elbow-arrow fields (`elbowed`,
+// `fixedSegments`, `fixedPoint`, …), no `polygon`, no `FixedPointBinding`.
+// `PointBinding` is metadata for later bound-element updates; first paint uses
+// the arrow's own `x`, `y`, and `points`, so we emit boundary coordinates.
 
 import type { Connector, Point, PrimitiveId, Radians } from '../primitives.js';
 import { baseElementFields } from '../utils/baseElementFields.js';
@@ -15,52 +19,60 @@ import { getLineHeight, measureText } from '../measure.js';
 import type {
   ExcalidrawArrowElement,
   ExcalidrawTextElement,
-  FixedPointBinding,
   PointBinding,
 } from '../types/excalidraw.js';
 import type { CompileContext, PrimitiveRecord } from '../compile/context.js';
 import { resolveEdgeStyle } from '../compile/resolveStyle.js';
 import { normalizePoints } from './shared/points.js';
 
-// Elbow arrows oscillate when fixedPoint == [0.5, 0.5] (issue #9197).
-// Nudge slightly off-centre; Excalidraw snaps to the correct face on first
-// interaction. See P17.
-const ELBOW_FIXED_POINT: readonly [number, number] = [0.4999, 0.5001];
-// Default gap between arrow endpoint and shape boundary.
+// Matches Excalidraw 0.17.x's minimum gap from calculateFocusAndGap().
 const DEFAULT_GAP = 1;
 
 function centerOfRecord(record: PrimitiveRecord): Point {
-  return [
-    record.bbox.x + record.bbox.w / 2,
-    record.bbox.y + record.bbox.h / 2,
-  ];
+  return [record.bbox.x + record.bbox.w / 2, record.bbox.y + record.bbox.h / 2];
 }
 
 function isPoint(ref: PrimitiveId | Point): ref is Point {
   return typeof ref !== 'string';
 }
 
-/**
- * Ray from the record's centre towards `towards` intersected with the
- * record's axis-aligned bbox. Used so arrow endpoints land on the near
- * edge of a bindable shape rather than its centre — matches Excalidraw's
- * native "connect two shapes" visual behaviour. Excalidraw's binding
- * still owns re-anchoring during drag; this only fixes the initial paint.
- */
-function boundaryPoint(record: PrimitiveRecord, towards: Point): Point {
-  const cx = record.bbox.x + record.bbox.w / 2;
-  const cy = record.bbox.y + record.bbox.h / 2;
-  const dx = towards[0] - cx;
-  const dy = towards[1] - cy;
+function rotatePoint(point: Point, center: Point, angle: number): Point {
+  if (angle === 0) return [point[0], point[1]];
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const dx = point[0] - center[0];
+  const dy = point[1] - center[1];
+  return [center[0] + dx * cos - dy * sin, center[1] + dx * sin + dy * cos];
+}
+
+function boundaryPoint(record: PrimitiveRecord, ctx: CompileContext, towards: Point): Point {
+  const element = ctx.getElementById(record.primaryId)!;
+  const center = centerOfRecord(record);
+  const localTowards = rotatePoint(towards, center, -element.angle);
+  const dx = localTowards[0] - center[0];
+  const dy = localTowards[1] - center[1];
   const absDx = Math.abs(dx);
   const absDy = Math.abs(dy);
-  if (absDx < 1e-6 && absDy < 1e-6) return [cx, cy];
+  if (absDx < 1e-6 && absDy < 1e-6) return center;
+
   const halfW = record.bbox.w / 2;
   const halfH = record.bbox.h / 2;
-  const tx = absDx > 1e-6 ? halfW / absDx : Number.POSITIVE_INFINITY;
-  const ty = absDy > 1e-6 ? halfH / absDy : Number.POSITIVE_INFINITY;
-  const t = Math.min(tx, ty);
-  return [cx + dx * t, cy + dy * t];
+  let t: number;
+  switch (element.type) {
+    case 'diamond':
+      t = 1 / (absDx / halfW + absDy / halfH);
+      break;
+    case 'ellipse':
+      t = 1 / Math.sqrt((dx * dx) / (halfW * halfW) + (dy * dy) / (halfH * halfH));
+      break;
+    default:
+      t = Math.min(
+        absDx > 1e-6 ? halfW / absDx : Number.POSITIVE_INFINITY,
+        absDy > 1e-6 ? halfH / absDy : Number.POSITIVE_INFINITY,
+      );
+  }
+
+  return rotatePoint([center[0] + dx * t, center[1] + dy * t], center, element.angle);
 }
 
 interface ResolvedEndpointCenter {
@@ -138,8 +150,7 @@ function buildRawPoints(
 function buildBinding(
   ref: PrimitiveId | Point,
   ctx: CompileContext,
-  isElbow: boolean,
-): { binding: PointBinding | FixedPointBinding | null; ownerId: string | null } {
+): { binding: PointBinding | null; ownerId: string | null } {
   if (isPoint(ref)) return { binding: null, ownerId: null };
   const record = ctx.getRecord(ref);
   if (!record) return { binding: null, ownerId: null };
@@ -147,15 +158,6 @@ function buildBinding(
   // Sticky and coverage primitives are intentionally excluded.
   if (record.kind !== 'labelBox' && record.kind !== 'frame') {
     return { binding: null, ownerId: null };
-  }
-  if (isElbow) {
-    const fixed: FixedPointBinding = {
-      elementId: record.primaryId,
-      focus: 0,
-      gap: DEFAULT_GAP,
-      fixedPoint: ELBOW_FIXED_POINT,
-    };
-    return { binding: fixed, ownerId: record.primaryId };
   }
   return {
     binding: { elementId: record.primaryId, focus: 0, gap: DEFAULT_GAP },
@@ -166,34 +168,19 @@ function buildBinding(
 export function emitConnector(p: Connector, ctx: CompileContext): void {
   const style = resolveEdgeStyle(p.style, ctx.theme, p.id, ctx);
   const routing = p.routing ?? 'straight';
-  const isElbow = routing === 'elbow';
 
-  // 1) Endpoints -> raw scene-coordinate points. Each endpoint that is a
-  //    reference to a bindable shape is anchored to the bbox edge nearest
-  //    the opposite endpoint, so the arrow starts/ends on the shape's
-  //    boundary rather than through its centre.
+  // 1) Endpoints -> scene-coordinate points. Bound references are anchored to
+  //    the boundary now because Excalidraw 0.17.x renders exactly these points.
   const fromRes = resolveCenter(p.from, ctx, p.id, 'from');
   const toRes = resolveCenter(p.to, ctx, p.id, 'to');
-  const start = fromRes.record
-    ? boundaryPoint(fromRes.record, toRes.center)
-    : fromRes.center;
-  const end = toRes.record
-    ? boundaryPoint(toRes.record, fromRes.center)
-    : toRes.center;
+  const start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
+  const end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
   const rawPoints = buildRawPoints(start, end, routing);
   const { points, width, height } = normalizePoints(rawPoints);
 
   // 2) Bindings
-  const { binding: startBinding, ownerId: startOwner } = buildBinding(
-    p.from,
-    ctx,
-    isElbow,
-  );
-  const { binding: endBinding, ownerId: endOwner } = buildBinding(
-    p.to,
-    ctx,
-    isElbow,
-  );
+  const { binding: startBinding, ownerId: startOwner } = buildBinding(p.from, ctx);
+  const { binding: endBinding, ownerId: endOwner } = buildBinding(p.to, ctx);
 
   const arrowId = newElementId();
   const base = baseElementFields({
@@ -226,12 +213,6 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
     endBinding,
     startArrowhead: p.arrowhead?.start ?? null,
     endArrowhead: p.arrowhead?.end ?? 'arrow',
-    elbowed: isElbow,
-    // Elbow arrows expect [] (not null) so Excalidraw's editor can populate it.
-    fixedSegments: isElbow ? [] : null,
-    startIsSpecial: false,
-    endIsSpecial: false,
-    polygon: false,
   };
 
   ctx.emit(arrow);
@@ -284,7 +265,7 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
       verticalAlign: 'middle',
       containerId: arrowId,
       lineHeight,
-      autoResize: true,
+      baseline: Math.round(fontSize * lineHeight * 0.8),
     };
 
     ctx.emit(label);

--- a/packages/core/src/emit/labelBox.ts
+++ b/packages/core/src/emit/labelBox.ts
@@ -2,9 +2,15 @@
 // plus an optional container-bound text child. See docs/03 §95-174.
 //
 // Pitfall guards exercised here:
-//   P4  — autoResize=false when we wrap, width/height driven by measureText
 //   P10 — roundness only on rectangle/diamond, never on ellipse
 //   C4  — bidirectional boundElements between shape and text
+//
+// Excalidraw 0.17.x quirks baked into the geometry choices below:
+//   - `baseline` is a REQUIRED field on text elements (0.18+ makes it
+//     optional + computed); omitting it leaves the label invisible.
+//   - `autoResize` does not exist yet; we position + size the text
+//     explicitly and Excalidraw's `redrawTextBoundingBox` will re-centre
+//     on first interaction without losing visibility in between.
 
 import type { LabelBox } from '../primitives.js';
 import { degreesToRadians } from '../utils/angle.js';
@@ -25,6 +31,20 @@ import type {
 import type { Radians } from '../primitives.js';
 import type { CompileContext } from '../compile/context.js';
 import { resolveNodeStyle } from '../compile/resolveStyle.js';
+
+/**
+ * Approximate the ascent (distance from the top of a line box down to the
+ * glyph baseline). Excalidraw 0.17.x stores this on each text element and
+ * feeds it into `fillText`; a missing or near-zero value drops the glyph
+ * below the clip rect and the label disappears.
+ *
+ * The ~90% ratio matches Excalifont / Virgil font metrics closely enough
+ * that the rendered glyph sits visually centered once `redrawTextBoundingBox`
+ * reconciles on first paint.
+ */
+function approximateBaseline(fontSize: number, lineHeight: number): number {
+  return Math.round(fontSize * lineHeight * 0.8);
+}
 
 const DEFAULT_PADDING = 20;
 // Fallbacks used only when `fit:'fixed'` is requested without a size.
@@ -125,18 +145,31 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
       fontSize,
       fontFamily,
     });
+    const wrappedMetrics = measureText({
+      text: wrapped,
+      fontSize,
+      fontFamily,
+      lineHeight,
+    });
+
+    // Size the text element to its measured glyph run (plus a single-pixel
+    // safety margin so aliasing doesn't clip edges) and center it inside
+    // the container. Excalidraw 0.17.x expects container-bound text to
+    // carry a real measured bbox + `baseline`; when those are missing or
+    // lie flush with the container rect, `refreshTextDimensions` clamps
+    // the run to zero and the label disappears.
+    const textWidth = Math.min(wrappedMetrics.width, width);
+    const textHeight = Math.min(wrappedMetrics.height, height);
+    const textX = commonBase.x + (width - textWidth) / 2;
+    const textY = commonBase.y + (height - textHeight) / 2;
 
     textId = newElementId();
-    // Excalidraw requires container-bound text to share the container's bbox;
-    // the renderer itself places the glyph run according to textAlign /
-    // verticalAlign. Emitting a smaller glyph-measured bbox makes the label
-    // clip or disappear (the B1 bug).
     const textBase = baseElementFields({
       id: textId,
-      x: commonBase.x,
-      y: commonBase.y,
-      width,
-      height,
+      x: textX,
+      y: textY,
+      width: textWidth,
+      height: textHeight,
       angle: 0 as Radians,
       strokeColor: style.strokeColor,
       backgroundColor: 'transparent',
@@ -162,8 +195,7 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
       verticalAlign: p.verticalAlign ?? 'middle',
       containerId: shapeId,
       lineHeight,
-      // Container-bound text never auto-resizes — width is container-driven. (P4)
-      autoResize: false,
+      baseline: approximateBaseline(fontSize, lineHeight),
     };
 
     // Wire the text into the shape's boundElements BEFORE emitting so the

--- a/packages/core/src/emit/line.ts
+++ b/packages/core/src/emit/line.ts
@@ -63,6 +63,9 @@ export function emitLine(p: Line, ctx: CompileContext): void {
     customData: { ...(p.customData ?? {}), drawcastPrimitiveId: p.id },
   });
 
+  // Excalidraw 0.17.x has no `polygon` field on lines; first==last already
+  // renders a closed polyline visually. The polyline is auto-closed above
+  // so the final look is identical.
   const element: ExcalidrawLineElement = {
     ...base,
     type: 'line',
@@ -71,7 +74,6 @@ export function emitLine(p: Line, ctx: CompileContext): void {
     lastCommittedPoint: null,
     startArrowhead: null,
     endArrowhead: null,
-    polygon: p.polygon === true,
   };
 
   ctx.emit(element);

--- a/packages/core/src/emit/sticky.ts
+++ b/packages/core/src/emit/sticky.ts
@@ -1,10 +1,9 @@
 // Emitter for the Sticky primitive: a free (container-less) text element.
 // See docs/03 §234-289.
 //
-// Pitfall guards:
-//   P4 — `autoResize` must match how we set width/text:
-//        - explicit width -> wrap + autoResize:false
-//        - no width       -> measure raw + autoResize:true
+// Excalidraw 0.17.x: no `autoResize` field, `baseline` is required.
+// We pre-wrap / pre-measure here so width/height are always correct and
+// rely on restore() to keep them in sync if the user edits the text.
 
 import type { Sticky } from '../primitives.js';
 import type { Radians } from '../primitives.js';
@@ -29,18 +28,16 @@ export function emitSticky(p: Sticky, ctx: CompileContext): void {
   let text: string;
   let width: number;
   let height: number;
-  let autoResize: boolean;
 
   if (p.width !== undefined) {
     // Fixed width: wrap to fit.
-    autoResize = false;
     width = p.width;
     text = wrapText({ text: p.text, maxWidth: width, fontSize, fontFamily });
     const m = measureText({ text, fontSize, fontFamily });
     height = m.height;
   } else {
-    // Auto: no wrapping, let Excalidraw auto-grow.
-    autoResize = true;
+    // Auto: no wrapping. Width/height are measured once here; restore()
+    // remeasures on edit.
     text = p.text;
     const m = measureText({ text: p.text, fontSize, fontFamily });
     width = m.width;
@@ -80,7 +77,7 @@ export function emitSticky(p: Sticky, ctx: CompileContext): void {
     verticalAlign: 'top',
     containerId: null,
     lineHeight,
-    autoResize,
+    baseline: Math.round(fontSize * lineHeight * 0.8),
   };
 
   ctx.emit(element);

--- a/packages/core/src/testing/compliance.ts
+++ b/packages/core/src/testing/compliance.ts
@@ -14,8 +14,6 @@ import type {
   ExcalidrawElement,
   ExcalidrawImageElement,
   ExcalidrawTextElement,
-  FixedPointBinding,
-  PointBinding,
 } from '../types/excalidraw.js';
 
 /** Stable code for each of the 10 compliance checks. */
@@ -229,7 +227,7 @@ function checkC5(elements: readonly ExcalidrawElement[]): ComplianceIssue[] {
   const byId = new Map(elements.map((el) => [el.id, el]));
   for (const el of elements) {
     if (!isArrow(el)) continue;
-    const sides: Array<['startBinding' | 'endBinding', PointBinding | FixedPointBinding | null]> = [
+    const sides: Array<['startBinding' | 'endBinding', typeof el.startBinding]> = [
       ['startBinding', el.startBinding],
       ['endBinding', el.endBinding],
     ];
@@ -378,52 +376,17 @@ function checkC9(elements: readonly ExcalidrawElement[]): ComplianceIssue[] {
 }
 
 // -----------------------------------------------------------------------------
-// C10 — Elbow arrows require FixedPointBinding (fixedPoint tuple).
+// C10 — Elbow-arrow FixedPointBinding check.
+//
+// Excalidraw 0.17.x has no elbow arrow concept — `elbowed`,
+// `fixedSegments`, `FixedPointBinding.fixedPoint` all land in 0.18+. Until
+// we bump the pinned version we can't meaningfully enforce this rule, so
+// the check is a no-op. Kept as a named function so the runner array
+// below doesn't need conditional wiring and the test IDs stay stable.
 // -----------------------------------------------------------------------------
 
-function isFixedPointBinding(
-  binding: PointBinding | FixedPointBinding | null,
-): binding is FixedPointBinding {
-  if (!binding) return false;
-  const fp = (binding as FixedPointBinding).fixedPoint;
-  return (
-    Array.isArray(fp) &&
-    fp.length === 2 &&
-    typeof fp[0] === 'number' &&
-    typeof fp[1] === 'number'
-  );
-}
-
-function checkC10(elements: readonly ExcalidrawElement[]): ComplianceIssue[] {
-  const issues: ComplianceIssue[] = [];
-  for (const el of elements) {
-    if (!isArrow(el)) continue;
-    if (!el.elbowed) continue;
-    const sides: Array<['startBinding' | 'endBinding', PointBinding | FixedPointBinding | null]> = [
-      ['startBinding', el.startBinding],
-      ['endBinding', el.endBinding],
-    ];
-    for (const [side, binding] of sides) {
-      if (!binding) continue;
-      if (!isFixedPointBinding(binding)) {
-        issues.push({
-          code: 'C10',
-          elementId: el.id,
-          message: `elbow arrow ${el.id}.${side} missing fixedPoint tuple`,
-        });
-        continue;
-      }
-      const [fx, fy] = binding.fixedPoint;
-      if (fx === 0.5 && fy === 0.5) {
-        issues.push({
-          code: 'C10',
-          elementId: el.id,
-          message: `elbow arrow ${el.id}.${side} fixedPoint exactly [0.5, 0.5] — oscillation risk (P17)`,
-        });
-      }
-    }
-  }
-  return issues;
+function checkC10(): ComplianceIssue[] {
+  return [];
 }
 
 // -----------------------------------------------------------------------------
@@ -448,7 +411,7 @@ export function runCompliance(
     { code: 'C7', run: () => checkC7(elements) },
     { code: 'C8', run: () => checkC8(elements) },
     { code: 'C9', run: () => checkC9(elements) },
-    { code: 'C10', run: () => checkC10(elements) },
+    { code: 'C10', run: () => checkC10() },
   ];
 
   const issues: ComplianceIssue[] = [];

--- a/packages/core/src/types/excalidraw.ts
+++ b/packages/core/src/types/excalidraw.ts
@@ -25,14 +25,15 @@ export interface BoundElement {
   id: string;
 }
 
-/** Binding used by non-elbow arrows. */
+/** Binding used by arrows. Excalidraw 0.17.x only understands this shape;
+ * FixedPointBinding (with `fixedPoint`) lands in 0.18+. */
 export interface PointBinding {
   elementId: string;
   focus: number;
   gap: number;
 }
 
-/** Binding used by elbow arrows. `fixedPoint` is AABB-normalized [0..1]. */
+/** @deprecated 0.17.x does not recognise `fixedPoint`; use PointBinding. */
 export interface FixedPointBinding extends PointBinding {
   fixedPoint: readonly [number, number];
 }
@@ -111,8 +112,11 @@ export interface ExcalidrawTextElement extends ExcalidrawElementBase {
   verticalAlign: 'top' | 'middle' | 'bottom';
   containerId: string | null;
   lineHeight: number;
-  autoResize: boolean;
-  baseline?: number;
+  // `baseline` is required by Excalidraw 0.17.x's restore(); omitting it
+  // leaves the text invisible because restore substitutes NaN for the
+  // glyph-vertical offset. 0.18+ derives it from font metrics, but the
+  // pinned version here does not.
+  baseline: number;
 }
 
 // -----------------------------------------------------------------------------
@@ -123,15 +127,10 @@ export interface ExcalidrawArrowElement extends ExcalidrawElementBase {
   type: 'arrow';
   points: LocalPoint[];
   lastCommittedPoint: LocalPoint | null;
-  startBinding: PointBinding | FixedPointBinding | null;
-  endBinding: PointBinding | FixedPointBinding | null;
+  startBinding: PointBinding | null;
+  endBinding: PointBinding | null;
   startArrowhead: Arrowhead | null;
   endArrowhead: Arrowhead | null;
-  elbowed: boolean;
-  fixedSegments: unknown[] | null;
-  startIsSpecial: boolean;
-  endIsSpecial: boolean;
-  polygon: boolean;
 }
 
 export interface ExcalidrawLineElement extends ExcalidrawElementBase {
@@ -140,7 +139,6 @@ export interface ExcalidrawLineElement extends ExcalidrawElementBase {
   lastCommittedPoint: LocalPoint | null;
   startArrowhead: Arrowhead | null;
   endArrowhead: Arrowhead | null;
-  polygon: boolean;
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/core/test/compile.test.ts
+++ b/packages/core/test/compile.test.ts
@@ -20,7 +20,6 @@ import type {
   ExcalidrawFrameElement,
   ExcalidrawRectangleElement,
   ExcalidrawTextElement,
-  FixedPointBinding,
 } from '../src/types/excalidraw.js';
 
 function makeScene(primitives: Primitive[]): Scene {
@@ -75,13 +74,20 @@ describe('compile — LabelBox with text', () => {
     expect(text.containerId).toBe(rect.id);
     expect(rect.boundElements).toContainEqual({ type: 'text', id: text.id });
 
-    // Text is wrapped -> container-bound, so autoResize must be false (P4).
-    expect(text.autoResize).toBe(false);
+    // Text preserves originalText verbatim.
     expect(text.originalText).toBe('Hello');
+    // `baseline` is required for Excalidraw 0.17.x to render the glyph.
+    expect(text.baseline).toBeGreaterThan(0);
 
     // Rectangle sized around the label center (auto fit).
     expect(rect.width).toBeGreaterThan(0);
     expect(rect.height).toBeGreaterThan(0);
+
+    // Text sits inside the rectangle (centre-aligned both axes).
+    expect(text.x).toBeGreaterThanOrEqual(rect.x);
+    expect(text.y).toBeGreaterThanOrEqual(rect.y);
+    expect(text.x + text.width).toBeLessThanOrEqual(rect.x + rect.width);
+    expect(text.y + text.height).toBeLessThanOrEqual(rect.y + rect.height);
   });
 });
 
@@ -138,13 +144,17 @@ describe('compile — Connector between two LabelBoxes', () => {
       expect.arrayContaining([{ type: 'arrow', id: arrow.id }]),
     );
 
-    // Straight arrow -> elbowed:false.
-    expect(arrow.elbowed).toBe(false);
+    // Both bindings carry focus:0, gap>0 so Excalidraw snaps the
+    // endpoints to the shape boundary on first paint.
+    expect(arrow.startBinding?.focus).toBe(0);
+    expect(arrow.endBinding?.focus).toBe(0);
+    expect(arrow.startBinding?.gap ?? 0).toBeGreaterThan(0);
+    expect(arrow.endBinding?.gap ?? 0).toBeGreaterThan(0);
   });
 });
 
-describe('compile — elbow connector (P17)', () => {
-  it('produces elbowed arrow with FixedPointBinding fixedPoint off-center', () => {
+describe('compile — elbow connector (0.17.x)', () => {
+  it('emits a standard PointBinding (no elbow-specific fields) in 0.17.x', () => {
     const boxA: LabelBox = {
       kind: 'labelBox',
       id: 'a' as PrimitiveId,
@@ -171,17 +181,14 @@ describe('compile — elbow connector (P17)', () => {
       result.elements,
       (el): el is ExcalidrawArrowElement => el.type === 'arrow',
     );
-    expect(arrow.elbowed).toBe(true);
-
-    // Both bindings must be FixedPointBinding (has fixedPoint) — P17.
-    const sb = arrow.startBinding as FixedPointBinding;
-    const eb = arrow.endBinding as FixedPointBinding;
-    expect(sb.fixedPoint).toEqual([0.4999, 0.5001]);
-    expect(eb.fixedPoint).toEqual([0.4999, 0.5001]);
-
-    // Must NOT be the oscillation-prone exact center.
-    expect(sb.fixedPoint[0]).not.toBe(0.5);
-    expect(sb.fixedPoint[1]).not.toBe(0.5);
+    // Elbow routing is simulated via the points array, but the
+    // `elbowed`/`fixedSegments`/`fixedPoint` fields don't exist in 0.17.x.
+    expect(arrow.startBinding?.focus).toBe(0);
+    expect(arrow.endBinding?.focus).toBe(0);
+    expect((arrow.startBinding as Record<string, unknown>).fixedPoint)
+      .toBeUndefined();
+    // 4-point L-shape: start -> horizontal -> vertical -> end.
+    expect(arrow.points.length).toBe(4);
   });
 });
 

--- a/packages/core/test/compliance.test.ts
+++ b/packages/core/test/compliance.test.ts
@@ -15,7 +15,6 @@ import type {
   ExcalidrawRectangleElement,
   ExcalidrawTextElement,
   FileId,
-  FixedPointBinding,
 } from '../src/types/excalidraw.js';
 import type {
   Connector,
@@ -49,7 +48,7 @@ function text(overrides: Partial<ExcalidrawTextElement> = {}): ExcalidrawTextEle
     verticalAlign: overrides.verticalAlign ?? 'top',
     containerId: overrides.containerId ?? null,
     lineHeight: overrides.lineHeight ?? 1.25,
-    autoResize: overrides.autoResize ?? true,
+    baseline: overrides.baseline ?? 16,
     ...overrides,
   };
 }
@@ -66,11 +65,6 @@ function arrow(overrides: Partial<ExcalidrawArrowElement> = {}): ExcalidrawArrow
     endBinding: null,
     startArrowhead: null,
     endArrowhead: 'arrow',
-    elbowed: false,
-    fixedSegments: null,
-    startIsSpecial: false,
-    endIsSpecial: false,
-    polygon: false,
     ...overrides,
   };
 }
@@ -196,45 +190,22 @@ describe('C9 — opacity range', () => {
   });
 });
 
-describe('C10 — elbow arrow binding', () => {
-  it('flags an elbow arrow whose binding lacks fixedPoint', () => {
+describe('C10 — elbow arrow binding (reserved for 0.18+)', () => {
+  // Excalidraw 0.17.x has no elbow-arrow concept. The check currently
+  // no-ops; once we bump the pinned version it should reactivate. The
+  // placeholder below pins the contract so regressions are visible.
+  it('no-ops on 0.17.x schema — legal to bind without fixedPoint', () => {
     const target = rect({
       id: 'r1',
       boundElements: [{ type: 'arrow', id: 'a1' }],
     });
     const a = arrow({
       id: 'a1',
-      elbowed: true,
-      fixedSegments: [],
       startBinding: { elementId: 'r1', focus: 0, gap: 1 },
     });
     const report = runCompliance([target, a], {});
-    expect(report.passed).toBe(false);
     const c10 = report.issues.filter((i) => i.code === 'C10');
-    expect(c10.some((i) => i.message.includes('missing fixedPoint'))).toBe(true);
-  });
-
-  it('warns when fixedPoint is exactly [0.5, 0.5] (P17 oscillation)', () => {
-    const target = rect({
-      id: 'r1',
-      boundElements: [{ type: 'arrow', id: 'a1' }],
-    });
-    const fp: FixedPointBinding = {
-      elementId: 'r1',
-      focus: 0,
-      gap: 1,
-      fixedPoint: [0.5, 0.5],
-    };
-    const a = arrow({
-      id: 'a1',
-      elbowed: true,
-      fixedSegments: [],
-      startBinding: fp,
-    });
-    const report = runCompliance([target, a], {});
-    expect(report.passed).toBe(false);
-    const c10 = report.issues.filter((i) => i.code === 'C10');
-    expect(c10.some((i) => i.message.includes('[0.5, 0.5]'))).toBe(true);
+    expect(c10).toEqual([]);
   });
 });
 

--- a/packages/core/test/coverage.test.ts
+++ b/packages/core/test/coverage.test.ts
@@ -95,10 +95,9 @@ describe('compile — Line', () => {
     expect(line.y).toBe(200);
     expect(line.width).toBe(50);
     expect(line.height).toBe(30);
-    expect(line.polygon).toBe(false);
   });
 
-  it('propagates polygon:true to the emitted element', () => {
+  it('polygon:true closes the polyline (first === last)', () => {
     const p: Line = {
       kind: 'line',
       id: 'tri' as PrimitiveId,
@@ -107,7 +106,6 @@ describe('compile — Line', () => {
         [0, 0],
         [40, 0],
         [20, 30],
-        [0, 0],
       ],
       polygon: true,
     };
@@ -116,7 +114,9 @@ describe('compile — Line', () => {
       result.elements,
       (el): el is ExcalidrawLineElement => el.type === 'line',
     );
-    expect(line.polygon).toBe(true);
+    // 0.17.x has no `polygon` field on line elements; the emitter
+    // simulates closure by ensuring the last point equals the first.
+    expect(line.points[0]).toEqual(line.points[line.points.length - 1]);
   });
 });
 

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -1,12 +1,12 @@
-// Connector endpoint-anchoring regression tests.
+// Connector endpoint + binding regression tests.
 //
-// Without this guard the emitter put arrow endpoints at the shape centres,
-// which visually reads as "the arrow pierces the box". The emitter now
-// intersects the ray between the two centres with each source/target
-// bounding box, so the arrow starts on the near edge and ends on the far
-// edge — matching user expectation and Excalidraw's own "connect two
-// shapes" behaviour. Bindings are retained so Excalidraw still auto-
-// re-anchors on drag.
+// The arrow is emitted with centre-to-centre points; Excalidraw re-anchors
+// the visible endpoints to each shape's boundary on first paint using
+// `startBinding.focus`/`gap`. Pre-calculating boundary points in the
+// emitter (an earlier attempt) races with Excalidraw's restore() and
+// leaves the arrow misaligned on the user-visible B3 bug. These tests
+// pin the invariants the compiled scene must carry so the first paint
+// lands correctly.
 
 import { describe, expect, it } from 'vitest';
 import { compile } from '../src/compile/index.js';
@@ -41,9 +41,11 @@ function findArrow(
 }
 
 describe('emitConnector — boundary anchoring (B3)', () => {
-  it('horizontal pair: arrow starts at source right edge, ends at target left edge', () => {
-    // A centred at (100,100), fixed 80x40 → right edge x = 140
-    // B centred at (300,100), fixed 80x40 → left  edge x = 260
+  it('horizontal pair: arrow lands on source right edge & target left edge', () => {
+    // A at (100,100) fixed 80x40 → right edge (140, 100).
+    // B at (300,100) fixed 80x40 → left edge (260, 100).
+    // Excalidraw 0.17.x renders exactly these points on first paint —
+    // bindings only take over on drag, so emit must pre-anchor.
     const a: LabelBox = {
       kind: 'labelBox',
       id: 'a' as PrimitiveId,
@@ -72,20 +74,22 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     const result = compile(makeScene([a, b, c]));
     const arrow = findArrow(result.elements);
 
-    // arrow.x (= start absolute x) should hug A's right edge, not its centre.
-    expect(arrow.x).toBeGreaterThan(135);
-    expect(arrow.x).toBeLessThanOrEqual(141);
+    // arrow origin == A's right edge midpoint.
+    expect(arrow.x).toBe(140);
+    expect(arrow.y).toBe(100);
 
-    // End absolute x = arrow.x + last point dx should hug B's left edge.
+    // Last point (in local coords) lands at B's left edge midpoint.
     const lastPoint = arrow.points[arrow.points.length - 1]!;
-    const endX = arrow.x + lastPoint[0];
-    expect(endX).toBeGreaterThanOrEqual(259);
-    expect(endX).toBeLessThan(265);
+    expect(arrow.x + lastPoint[0]).toBe(260);
+    expect(arrow.y + lastPoint[1]).toBe(100);
+
+    // Bindings persisted so drag-re-anchor still works.
+    expect(arrow.startBinding?.focus).toBe(0);
+    expect(arrow.endBinding?.focus).toBe(0);
+    expect(arrow.startBinding?.gap ?? 0).toBeGreaterThan(0);
   });
 
-  it('vertical pair: arrow starts at source bottom edge, ends at target top edge', () => {
-    // A (100,100) 80x40 → bottom edge y = 120
-    // B (100,300) 80x40 → top    edge y = 280
+  it('vertical pair: arrow lands on source bottom edge & target top edge', () => {
     const a: LabelBox = {
       kind: 'labelBox',
       id: 'a' as PrimitiveId,
@@ -114,13 +118,13 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     const result = compile(makeScene([a, b, c]));
     const arrow = findArrow(result.elements);
 
-    expect(arrow.y).toBeGreaterThan(115);
-    expect(arrow.y).toBeLessThanOrEqual(121);
+    // A's bottom edge midpoint = (100, 120); B's top edge = (100, 280).
+    expect(arrow.x).toBe(100);
+    expect(arrow.y).toBe(120);
 
     const lastPoint = arrow.points[arrow.points.length - 1]!;
-    const endY = arrow.y + lastPoint[1];
-    expect(endY).toBeGreaterThanOrEqual(279);
-    expect(endY).toBeLessThan(285);
+    expect(arrow.x + lastPoint[0]).toBe(100);
+    expect(arrow.y + lastPoint[1]).toBe(280);
   });
 
   it('keeps startBinding / endBinding so Excalidraw still auto-re-anchors', () => {

--- a/packages/core/test/emit-labelBox.test.ts
+++ b/packages/core/test/emit-labelBox.test.ts
@@ -1,11 +1,15 @@
 // LabelBox geometry regression tests.
 //
-// Excalidraw's container-bound text renders correctly only when the text
-// element shares the container's bounding box (x, y, width, height); the
-// renderer itself positions the glyph run according to textAlign /
-// verticalAlign. Emitting the text with the measured glyph bbox instead of
-// the container bbox causes the label to either clip or disappear — which
-// is the user-visible B1 bug this file guards against.
+// Excalidraw 0.17.x renders container-bound text only when:
+//   1. `containerId` points to the shape's id
+//   2. The shape lists the text in `boundElements`
+//   3. `baseline` is a positive integer (required field; missing -> NaN
+//      -> text falls below the clip rect and disappears)
+//
+// The text element's x/y/width/height should fit *inside* the container
+// (not exceed the container bbox). Text bboxes that exactly match the
+// container bbox trigger Excalidraw's `refreshTextDimensions` to clamp
+// the glyph run to zero on first paint — the user-visible B1 bug.
 
 import { describe, expect, it } from 'vitest';
 import { compile } from '../src/compile/index.js';
@@ -28,7 +32,7 @@ function makeScene(primitives: LabelBox[]): Scene {
 }
 
 describe('emitLabelBox — container-bound text geometry (B1)', () => {
-  it('text element shares the container bbox so Excalidraw renders it', () => {
+  it('text element sits inside the container bbox with baseline set', () => {
     const p: LabelBox = {
       kind: 'labelBox',
       id: 'n1' as PrimitiveId,
@@ -45,11 +49,13 @@ describe('emitLabelBox — container-bound text geometry (B1)', () => {
     )!;
 
     expect(text.containerId).toBe(shape.id);
-    expect(text.x).toBe(shape.x);
-    expect(text.y).toBe(shape.y);
-    expect(text.width).toBe(shape.width);
-    expect(text.height).toBe(shape.height);
-    expect(text.autoResize).toBe(false);
+    // Centred horizontally.
+    expect(text.x + text.width / 2).toBeCloseTo(shape.x + shape.width / 2, 1);
+    // Fits inside.
+    expect(text.width).toBeLessThanOrEqual(shape.width);
+    expect(text.height).toBeLessThanOrEqual(shape.height);
+    // Excalidraw 0.17.x requires a real baseline value.
+    expect(text.baseline).toBeGreaterThan(0);
   });
 
   it('preserves originalText verbatim and emits wrapped glyph run', () => {
@@ -70,7 +76,7 @@ describe('emitLabelBox — container-bound text geometry (B1)', () => {
     expect(text.text).toMatch(/Hello/);
   });
 
-  it('fixed-size box still places text at the container bbox', () => {
+  it('fixed-size box centres text within the container', () => {
     const p: LabelBox = {
       kind: 'labelBox',
       id: 'n1' as PrimitiveId,
@@ -90,10 +96,12 @@ describe('emitLabelBox — container-bound text geometry (B1)', () => {
 
     expect(shape.width).toBe(120);
     expect(shape.height).toBe(80);
-    expect(text.x).toBe(shape.x);
-    expect(text.y).toBe(shape.y);
-    expect(text.width).toBe(120);
-    expect(text.height).toBe(80);
+    // Text fits inside.
+    expect(text.width).toBeLessThanOrEqual(120);
+    expect(text.height).toBeLessThanOrEqual(80);
+    // Centred (to within rounding).
+    expect(text.x + text.width / 2).toBeCloseTo(shape.x + shape.width / 2, 1);
+    expect(text.y + text.height / 2).toBeCloseTo(shape.y + shape.height / 2, 1);
   });
 
   it('shape still registers the text in boundElements so Excalidraw pairs them', () => {


### PR DESCRIPTION
## Summary

Three bugs converged on a schema mismatch: the compile pipeline was emitting Excalidraw 0.18+ shapes (elbow arrows, `autoResize`, `polygon`, `FixedPointBinding`) while the app pins `@excalidraw/excalidraw@0.17.6`. The missing required `baseline` field on text elements was leaving labels invisible.

### Bugs fixed

1. **Node text invisible** — container-bound text elements now carry the required `baseline` and are sized to their measured glyph run + centred inside the container (a container-bbox-sized text was getting clipped to zero by `refreshTextDimensions`).
2. **Arrow endpoints drifting off edge midpoints** — Excalidraw 0.17.x renders `element.points` verbatim on first paint; `focus`/`gap` only kick in on drag. The connector emitter now pre-anchors endpoints on shape boundaries via a rotation-aware `boundaryPoint()` that handles rectangle / diamond / ellipse.
3. **Chat UI: empty ghost bubbles + uncollapsible tool cards + no thinking support** — `thinking` content blocks are now surfaced as assistant-ui `reasoning` parts, empty assistant events are filtered at the store level, `StreamingCursor` only renders while running, and `ToolCallUI` persists open state in a module-level `Map<toolCallId, boolean>` because assistant-ui keys parts by index (plain `useState` gets wiped when a streaming tick reorders parts).

### Scope

- `@drawcast/core` emit layer (`labelBox`, `connector`, `sticky`, `line`) realigned to 0.17.6
- `@drawcast/core` types + compliance runner trimmed of fields not present in 0.17.6
- `@drawcast/app` chat panel: `thinking` ingestion, memoized adapter, new `ReasoningUI`, toolCallId-keyed tool card state
- New `packages/app/src/panels/chat/ReasoningUI.tsx`

### Test plan

- [x] `pnpm --filter @drawcast/core test` — 69/69
- [x] `pnpm --filter @drawcast/app test` — 49/49
- [x] `pnpm --filter @drawcast/mcp-server test` — 119/119
- [x] `pnpm -r typecheck`, `pnpm -r lint` — clean
- [x] `pnpm --filter @drawcast/app tauri dev` — verified in running app: box labels render, arrows land on edge midpoints, chat shows tool cards + thinking accordions without ghost bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying AI reasoning and extended thinking in chat messages with a collapsible interface.

* **Improvements**
  * Enhanced tool call card state persistence across UI remounts.
  * Updated text baseline and alignment for improved diagram rendering.
  * Refined endpoint anchoring for diagram connectors.

* **Changes**
  * Removed elbow-style arrow connectors from diagrams.
  * Updated diagram text sizing behavior for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->