### PR TITLE
fix(mcp-server): sanitize literal \n in label text to real newline

### DIFF
--- a/packages/mcp-server/src/tools/drawUpsertBox.ts
+++ b/packages/mcp-server/src/tools/drawUpsertBox.ts
@@ -26,6 +26,7 @@ import {
   normalizeStyleRef,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
+import { sanitizeLabelText } from './helpers/textSanitize.js';
 
 const ShapeSchema = z.enum(['rectangle', 'ellipse', 'diamond']);
 const TextAlignSchema = z.enum(['left', 'center', 'right']);
@@ -139,7 +140,7 @@ export const drawUpsertBox = defineTool({
       id: args.id as PrimitiveId,
       shape: args.shape ?? 'rectangle',
       at: [args.at[0], args.at[1]],
-      ...(args.text !== undefined && { text: args.text }),
+      ...(args.text !== undefined && { text: sanitizeLabelText(args.text) }),
       ...(args.style !== undefined && { style: normalizeStyleRef(args.style) }),
       ...(args.fit !== undefined && { fit: args.fit }),
       ...(args.size !== undefined && {

--- a/packages/mcp-server/src/tools/drawUpsertEdge.ts
+++ b/packages/mcp-server/src/tools/drawUpsertEdge.ts
@@ -24,6 +24,7 @@ import {
   normalizeStyleRef,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
+import { sanitizeLabelText } from './helpers/textSanitize.js';
 
 const EndpointSchema = z.union([z.string().min(1), PointSchema]);
 const RoutingSchema = z.enum(['straight', 'elbow', 'curved']);
@@ -142,7 +143,7 @@ export const drawUpsertEdge = defineTool({
       id: args.id as PrimitiveId,
       from: resolveEndpoint(args.from),
       to: resolveEndpoint(args.to),
-      ...(args.label !== undefined && { label: args.label }),
+      ...(args.label !== undefined && { label: sanitizeLabelText(args.label) }),
       ...(args.routing !== undefined && { routing: args.routing }),
       ...(args.arrowhead !== undefined && {
         arrowhead: {

--- a/packages/mcp-server/src/tools/drawUpsertFrame.ts
+++ b/packages/mcp-server/src/tools/drawUpsertFrame.ts
@@ -22,6 +22,7 @@ import {
   normalizeReturnPreview,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
+import { sanitizeLabelText } from './helpers/textSanitize.js';
 
 export const drawUpsertFrameInputSchema = z.object({
   id: z.string().min(1),
@@ -95,7 +96,7 @@ export const drawUpsertFrame = defineTool({
       at: [args.at[0], args.at[1]],
       size: [args.size[0], args.size[1]] as const,
       children: args.children.map((c) => c as PrimitiveId),
-      ...(args.title !== undefined && { title: args.title }),
+      ...(args.title !== undefined && { title: sanitizeLabelText(args.title) }),
       ...(args.magic !== undefined && { magic: args.magic }),
       ...(args.angle !== undefined && { angle: args.angle }),
       ...(args.locked !== undefined && { locked: args.locked }),

--- a/packages/mcp-server/src/tools/drawUpsertSticky.ts
+++ b/packages/mcp-server/src/tools/drawUpsertSticky.ts
@@ -24,6 +24,7 @@ import {
   normalizeStyleRef,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
+import { sanitizeLabelText } from './helpers/textSanitize.js';
 
 const TextAlignSchema = z.enum(['left', 'center', 'right']);
 
@@ -101,7 +102,7 @@ export const drawUpsertSticky = defineTool({
     const sticky: Sticky = {
       kind: 'sticky',
       id: args.id as PrimitiveId,
-      text: args.text,
+      text: sanitizeLabelText(args.text),
       at: [args.at[0], args.at[1]],
       ...(args.width !== undefined && { width: args.width }),
       ...(args.style !== undefined && { style: normalizeStyleRef(args.style) }),

--- a/packages/mcp-server/src/tools/helpers/textSanitize.ts
+++ b/packages/mcp-server/src/tools/helpers/textSanitize.ts
@@ -1,0 +1,27 @@
+// Normalise label text that MCP clients sometimes deliver with literal
+// escape sequences.
+//
+// Why: Claude occasionally double-encodes a newline as the two characters
+// `\n` (backslash + n) when it emits JSON inside a tool call — typically
+// because the diagramming convention it was taught elsewhere (Mermaid,
+// dot notation) uses a literal `\n`. Excalidraw renders whatever string
+// we hand it verbatim, so the backslash-n ends up visible on the node
+// label instead of producing a line break.
+//
+// We normalise at the MCP tool boundary so the scene store, emit
+// pipeline, and query tools never have to double-check. A single pass is
+// enough because a JSON-decoded input of `"\\n"` arrives here as two
+// characters (`\` + `n`) — never as four.
+
+/**
+ * Convert any stray literal `\n` (two characters: backslash + n) inside
+ * the input into a real `\n` newline. Real newlines pass through
+ * untouched, so the helper is idempotent: `f(f(x)) === f(x)`.
+ *
+ * Scope is deliberately narrow. `\t` / `\r` show up rarely in diagram
+ * labels; if the model starts producing them we can extend this helper
+ * rather than sprinkling additional replacements at the call sites.
+ */
+export function sanitizeLabelText(text: string): string {
+  return text.replace(/\\n/g, '\n');
+}

--- a/packages/mcp-server/test/tools.box.test.ts
+++ b/packages/mcp-server/test/tools.box.test.ts
@@ -174,4 +174,17 @@ describe('draw_upsert_box', () => {
     expect(result.content).toHaveLength(1);
     expect(result.content[0]).toMatchObject({ type: 'text' });
   });
+
+  it('converts a literal \\n inside the text into a real newline', async () => {
+    // Regression: some MCP clients double-encode newlines as the two
+    // characters `\` + `n`, which would otherwise land in Excalidraw as
+    // a visible glyph instead of a line break.
+    const store = new SceneStore();
+    await drawUpsertBox.execute(
+      { id: 'decision', at: [0, 0], text: '재시도 횟수\\n초과?' },
+      store,
+    );
+    const stored = store.getPrimitive(asId('decision')) as LabelBox;
+    expect(stored.text).toBe('재시도 횟수\n초과?');
+  });
 });

--- a/packages/mcp-server/test/tools.edge.test.ts
+++ b/packages/mcp-server/test/tools.edge.test.ts
@@ -156,4 +156,16 @@ describe('draw_upsert_edge', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
   });
+
+  it('converts a literal \\n inside the edge label into a real newline', async () => {
+    // Regression: mirrors the box/sticky sanitizer — edge labels take the
+    // same path so the same double-escape hazard applies.
+    const store = new SceneStore();
+    await drawUpsertEdge.execute(
+      { id: 'e', from: 'a', to: 'b', label: 'retry\\nif failed' },
+      store,
+    );
+    const stored = store.getPrimitive(asId('e')) as Connector;
+    expect(stored.label).toBe('retry\nif failed');
+  });
 });

--- a/packages/mcp-server/test/tools.sticky.test.ts
+++ b/packages/mcp-server/test/tools.sticky.test.ts
@@ -136,4 +136,17 @@ describe('draw_upsert_sticky', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
   });
+
+  it('converts a literal \\n inside sticky text into a real newline', async () => {
+    // Regression: the tool description advertises "\\n" as the multi-line
+    // separator, so clients that send the literal backslash-n must still
+    // render as an actual line break.
+    const store = new SceneStore();
+    await drawUpsertSticky.execute(
+      { id: 'legend', text: 'line1\\nline2', at: [0, 0] },
+      store,
+    );
+    const stored = store.getPrimitive(asId('legend')) as Sticky;
+    expect(stored.text).toBe('line1\nline2');
+  });
 });

--- a/packages/mcp-server/test/tools.structural.test.ts
+++ b/packages/mcp-server/test/tools.structural.test.ts
@@ -200,4 +200,22 @@ describe('draw_upsert_frame', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
   });
+
+  it('converts a literal \\n inside the frame title into a real newline', async () => {
+    // Regression: frame titles carry the same multi-line hazard as box
+    // text / edge labels.
+    const store = new SceneStore();
+    await drawUpsertFrame.execute(
+      {
+        id: 'f',
+        title: 'Sprint 1\\nWeek 1',
+        at: [0, 0],
+        size: [400, 300],
+        children: [],
+      },
+      store,
+    );
+    const stored = store.getPrimitive(asId('f')) as Frame;
+    expect(stored.title).toBe('Sprint 1\nWeek 1');
+  });
 });

--- a/packages/mcp-server/test/tools.textSanitize.test.ts
+++ b/packages/mcp-server/test/tools.textSanitize.test.ts
@@ -1,0 +1,39 @@
+// Unit coverage for the label-text sanitiser shared by every upsert tool
+// that accepts user-authored text (box / edge / sticky / frame).
+
+import { describe, expect, it } from 'vitest';
+import { sanitizeLabelText } from '../src/tools/helpers/textSanitize.js';
+
+describe('sanitizeLabelText', () => {
+  it('leaves plain text untouched', () => {
+    expect(sanitizeLabelText('hello')).toBe('hello');
+  });
+
+  it('leaves real newlines untouched', () => {
+    expect(sanitizeLabelText('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('converts a literal backslash-n into a real newline', () => {
+    // The source string contains two characters: backslash + 'n'.
+    expect(sanitizeLabelText('line1\\nline2')).toBe('line1\nline2');
+  });
+
+  it('handles mixed real and literal newlines', () => {
+    expect(sanitizeLabelText('a\nb\\nc')).toBe('a\nb\nc');
+  });
+
+  it('converts multiple literal newlines in the same string', () => {
+    expect(sanitizeLabelText('재시도 횟수\\n초과?\\n재시도')).toBe(
+      '재시도 횟수\n초과?\n재시도',
+    );
+  });
+
+  it('is idempotent', () => {
+    const once = sanitizeLabelText('a\\nb');
+    expect(sanitizeLabelText(once)).toBe(once);
+  });
+
+  it('handles empty strings', () => {
+    expect(sanitizeLabelText('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Claude sometimes double-encodes newlines as the two-character sequence `\n` (backslash + n) inside tool-call JSON. Excalidraw renders the payload verbatim, so the escape sequence ended up visible on node/edge/sticky/frame labels instead of producing a line break.
- New `sanitizeLabelText` helper converts literal `\n` → real newline at the MCP tool boundary (idempotent, leaves real newlines alone).
- Applied in `draw_upsert_{box,edge,sticky,frame}` so the scene store, emit pipeline, and query tools all see real newlines.

## Why tool boundary (not emit)
Normalising once at ingress keeps the store, SSE payloads, and `draw_list*` responses consistent with what Excalidraw eventually renders. This matches the issue author's recommendation.

## Scope
- `draw_upsert_shape` has no text field → not in scope.
- `drawExport.title` is Obsidian-markdown metadata and is not rendered to a text element → not in scope.
- System-prompt guidance for newline usage belongs to #21 → not in this PR.
- `\t` / `\r` literals excluded (YAGNI — helper is easy to extend if they appear).

## Test plan
- [x] `pnpm --filter @drawcast/mcp-server test` — 130/130 pass (11 new: 7 unit + 4 regression)
- [x] `pnpm --filter @drawcast/mcp-server lint` — clean
- [x] `pnpm --filter @drawcast/mcp-server typecheck` — clean
- [ ] Manual smoke: trigger the repro scenario from the issue (`로그인 BP 흐름에 대해서 다이어그램 그려줘`) and confirm diamond-node label renders on two lines

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text field handling across drawing elements. Text containing newline escape sequences (`\n`) now properly renders as actual line breaks instead of literal characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->