### PR TITLE
fix(core): edge label fontSize uses theme default

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -226,7 +226,7 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
   if (p.label) {
     const labelId = newElementId();
     const fontFamily = style.fontFamily ?? ctx.theme.defaultFontFamily;
-    const fontSize = style.fontSize ?? 16;
+    const fontSize = style.fontSize ?? ctx.theme.defaultFontSize;
     const lineHeight = getLineHeight(fontFamily);
     const metrics = measureText({ text: p.label, fontSize, fontFamily });
     // Midpoint of the raw (pre-normalisation) points: visually unimportant


### PR DESCRIPTION
## Summary
- `connector.ts` hardcoded edge label fontSize to 16 while `labelBox`/`sticky` fall back to `theme.defaultFontSize` (20). Edge labels rendered noticeably smaller than node labels, which the eval VLM rubric consistently flagged as readability issues.
- Changed fallback to match the other emitters: `style.fontSize ?? ctx.theme.defaultFontSize`.

## Evidence
- Baseline (`evals/baselines/2026-04-20T05-49-59Z`) — readability mean **2.07 / 3**, with VLM notes repeatedly citing small edge labels (예/아니오/재입력).
- Before fix: `flow-login-01` sample edge labels emit `fontSize: 16`.
- After fix: same question re-run produces edge labels at `fontSize: 20` (node default), both runs `verdict: pass`.
- All 69 `@drawcast/core` unit tests pass (`pnpm --filter @drawcast/core test`).

## Test plan
- [x] `pnpm --filter @drawcast/core test`
- [x] `pnpm --filter @drawcast/mcp-server test`
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01` (pass)
- [ ] Follow-up: re-run full baseline (`--n 3`) to confirm readability mean shifts upward

🤖 Generated with [Claude Code](https://claude.com/claude-code)