### PR TITLE
fix(mcp-server): decode literal \n in label text

### DIFF
--- a/packages/mcp-server/src/tools/drawUpsertBox.ts
+++ b/packages/mcp-server/src/tools/drawUpsertBox.ts
@@ -24,6 +24,7 @@ import {
   formatZodError,
   normalizeReturnPreview,
   normalizeStyleRef,
+  normalizeUserText,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
 
@@ -139,7 +140,7 @@ export const drawUpsertBox = defineTool({
       id: args.id as PrimitiveId,
       shape: args.shape ?? 'rectangle',
       at: [args.at[0], args.at[1]],
-      ...(args.text !== undefined && { text: args.text }),
+      ...(args.text !== undefined && { text: normalizeUserText(args.text) }),
       ...(args.style !== undefined && { style: normalizeStyleRef(args.style) }),
       ...(args.fit !== undefined && { fit: args.fit }),
       ...(args.size !== undefined && {

--- a/packages/mcp-server/src/tools/drawUpsertEdge.ts
+++ b/packages/mcp-server/src/tools/drawUpsertEdge.ts
@@ -22,6 +22,7 @@ import {
   formatZodError,
   normalizeReturnPreview,
   normalizeStyleRef,
+  normalizeUserText,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
 
@@ -142,7 +143,7 @@ export const drawUpsertEdge = defineTool({
       id: args.id as PrimitiveId,
       from: resolveEndpoint(args.from),
       to: resolveEndpoint(args.to),
-      ...(args.label !== undefined && { label: args.label }),
+      ...(args.label !== undefined && { label: normalizeUserText(args.label) }),
       ...(args.routing !== undefined && { routing: args.routing }),
       ...(args.arrowhead !== undefined && {
         arrowhead: {

--- a/packages/mcp-server/src/tools/drawUpsertFrame.ts
+++ b/packages/mcp-server/src/tools/drawUpsertFrame.ts
@@ -20,6 +20,7 @@ import {
   SizeSchema,
   formatZodError,
   normalizeReturnPreview,
+  normalizeUserText,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
 
@@ -95,7 +96,7 @@ export const drawUpsertFrame = defineTool({
       at: [args.at[0], args.at[1]],
       size: [args.size[0], args.size[1]] as const,
       children: args.children.map((c) => c as PrimitiveId),
-      ...(args.title !== undefined && { title: args.title }),
+      ...(args.title !== undefined && { title: normalizeUserText(args.title) }),
       ...(args.magic !== undefined && { magic: args.magic }),
       ...(args.angle !== undefined && { angle: args.angle }),
       ...(args.locked !== undefined && { locked: args.locked }),

--- a/packages/mcp-server/src/tools/drawUpsertSticky.ts
+++ b/packages/mcp-server/src/tools/drawUpsertSticky.ts
@@ -22,6 +22,7 @@ import {
   formatZodError,
   normalizeReturnPreview,
   normalizeStyleRef,
+  normalizeUserText,
 } from './utils.js';
 import { requestScenePreview } from './helpers/preview.js';
 
@@ -101,7 +102,7 @@ export const drawUpsertSticky = defineTool({
     const sticky: Sticky = {
       kind: 'sticky',
       id: args.id as PrimitiveId,
-      text: args.text,
+      text: normalizeUserText(args.text),
       at: [args.at[0], args.at[1]],
       ...(args.width !== undefined && { width: args.width }),
       ...(args.style !== undefined && { style: normalizeStyleRef(args.style) }),

--- a/packages/mcp-server/src/tools/utils.ts
+++ b/packages/mcp-server/src/tools/utils.ts
@@ -97,6 +97,25 @@ export const FontFamilySchema = z.union([
 ]);
 
 /**
+ * Convert two-character backslash escapes (`\n`, `\r\n`, `\t`) that LLM
+ * clients commonly emit verbatim inside JSON string arguments into real
+ * control characters. Without this, a tool input like
+ * `"text": "foo\\n(bar)"` renders the literal two-char sequence `\n` instead
+ * of a line break.
+ *
+ * Why: Claude and other LLM clients occasionally over-escape multi-line
+ * labels ("\\n" in the JSON source → two chars backslash+n after parse).
+ * Diagram labels never legitimately contain a literal `\n` sequence, so
+ * unescaping is safe.
+ */
+export function normalizeUserText(text: string): string {
+  return text
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t');
+}
+
+/**
  * Format a zod error for `isError` content. Keeps the message short and
  * targeted — we cannot dump the full pretty-printed tree through an MCP
  * text block because clients vary in how they render newlines.

--- a/packages/mcp-server/test/tools.box.test.ts
+++ b/packages/mcp-server/test/tools.box.test.ts
@@ -46,6 +46,20 @@ describe('draw_upsert_box', () => {
     expect(stored.at).toEqual([100, 200]);
   });
 
+  it('normalises literal "\\n" escape sequences in text into real newlines', async () => {
+    const store = new SceneStore();
+    await drawUpsertBox.execute(
+      {
+        id: 'multi-line',
+        text: '입력 오류 표시\\n(형식 불일치)',
+        at: [0, 0],
+      },
+      store,
+    );
+    const stored = store.getPrimitive(asId('multi-line')) as LabelBox;
+    expect(stored.text).toBe('입력 오류 표시\n(형식 불일치)');
+  });
+
   it('defaults shape to rectangle when omitted', async () => {
     const store = new SceneStore();
     await drawUpsertBox.execute({ id: 'a', at: [0, 0] }, store);


### PR DESCRIPTION
## Summary

- LLM clients (Claude) sometimes over-escape multi-line label text so the JSON tool input contains `"\\n"` — two chars (backslash + n) — instead of a real newline. The MCP server was storing that verbatim, so rendered diagrams showed literal `\n` inside labels.
- Added `normalizeUserText` helper and applied it at every tool entry that accepts user-visible text (box `text`, sticky `text`, edge `label`, frame `title`). Diagram labels never legitimately contain a literal `\n` sequence, so unescaping is safe.

## Root cause (from eval trace)

Trace for `flow-login-01` sample-1 showed Claude's `draw_upsert_box` input contained `"text": "입력 오류 메시지 표시\\n(형식 불일치)"`. The scene JSON persisted the same literal, and the Playwright-based Excalidraw render surfaced `\n` as on-screen characters.

## Verification

- Reproduced with `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` before the fix — rendered PNG showed `입력 오류 메시지 표시\n(형식 불일치)` as one line with a visible backslash-n.
- Re-ran the exact same eval after the fix — same scene JSON no longer contains `\\n` and the rendered PNG now shows the label as a proper two-line block.
- `pnpm --filter @drawcast/mcp-server test` → 120 tests pass, including a new regression test in `tools.box.test.ts` asserting that `"...\\n..."` is stored as a real newline.

## Test plan

- [x] `pnpm --filter @drawcast/mcp-server test`
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` (before/after PNG comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)