### PR TITLE
feat(mcp-server): advertise layout instructions in initialize

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -46,6 +46,19 @@ export interface DrawcastServer {
 const DEFAULT_NAME = 'drawcast-mcp';
 const DEFAULT_VERSION = '0.0.0';
 
+// Layout guidance surfaced via the MCP initialize `instructions` field.
+// Clients (Claude Code, Codex) expose this to the drawing agent so it
+// plans spacing and routing before issuing upserts. Keep terse — the
+// agent re-reads it at every invocation.
+const DEFAULT_INSTRUCTIONS = `You are drawing a diagram into a shared Excalidraw scene via draw_upsert_* tools. Follow these layout rules so the rendered result is readable:
+
+1. Plan the grid before drawing. Pick a main-flow column (e.g. x=400) and branch columns ≥250px to the side (e.g. x=150 / x=650). Rows step by ≥140px (y=50, 190, 330, ...). Default box size is roughly 200×65, so adjacent box centers must stay ≥280px apart horizontally and ≥140px apart vertically to avoid overlap.
+2. Route feedback / loop / cross-diagram edges with routing:"elbow" AND keep them in a dedicated outer lane ≥200px away from every main-flow box. Example: if the main column centers at x=400 with 200px-wide boxes (edges at x=300–500), put a left-side feedback lane at x ≤ 100 and a right-side lane at x ≥ 700. Leave room for the edge label on that lane (≥120px of clear space to the nearest box edge) so it does not collide with box borders or other edges. Never let a long edge cross over a non-endpoint node.
+3. Keep edge labels short (≤8 chars, e.g. "예"/"아니오"/"success"/"fail"). Long labels collide with neighbouring boxes; move detail into the connected box's text instead.
+4. Branches go in their own columns. For decision diamonds, place the "yes" child and "no" child in different columns at the same y row, then merge below if needed.
+5. Upsert ids should be stable — re-upserting the same id repositions rather than duplicating. Prefer getting coordinates right the first time over iterative nudges.
+6. End the session as soon as the diagram is complete. The host runner fetches the scene via draw_export automatically, so you do not need to call draw_export yourself unless asked.`;
+
 export function createServer(options: CreateServerOptions = {}): DrawcastServer {
   const name = options.name ?? DEFAULT_NAME;
   const version = options.version ?? DEFAULT_VERSION;
@@ -58,6 +71,7 @@ export function createServer(options: CreateServerOptions = {}): DrawcastServer 
       capabilities: {
         tools: {},
       },
+      instructions: DEFAULT_INSTRUCTIONS,
     },
   );
 

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -68,6 +68,15 @@ describe('createServer', () => {
     await client.close();
   });
 
+  it('advertises layout instructions in the initialize response', async () => {
+    const { client } = await connectPair();
+    const instructions = client.getInstructions();
+    expect(typeof instructions).toBe('string');
+    expect(instructions).toMatch(/elbow/);
+    expect(instructions).toMatch(/layout/i);
+    await client.close();
+  });
+
   it('returns an isError response when tools/call hits an unknown tool', async () => {
     const { client } = await connectPair({ tools: [] });
     const result = await client.callTool({


### PR DESCRIPTION
## Summary
- Adds MCP server-level \`instructions\` (via SDK \`ServerOptions.instructions\`) with six layout rules: grid planning, outer-lane routing for feedback/loop edges, short labels, branch columns, stable upsert ids, and no voluntary \`draw_export\`.
- New unit test verifies the instructions are surfaced through \`tools/initialize\` (client receives them via \`getInstructions()\`).
- Motivated by an E2E pass on \`flow-login-01\`: the baseline routed the feedback edge (\`retry_check → input\`) straight through the main column, covering \`auth\` and \`auth_check\`. Follow-up runs after the change consistently moved feedback edges to left/right outer lanes.

## Evidence
- Baseline: layout 3/5, edge crossings visible in \`evals/results/2026-04-21T02-01-39Z/flow-login-01.sample-1.png\` (retry_check→input crosses the center column).
- Post-fix runs (3x): all pass; rubric totals 1.0 / 0.87 / 0.913. Feedback lanes routed outside the main column. Rubric layout axis is noisy at single-sample n=1.
- All 131 \`@drawcast/mcp-server\` tests pass.

## Test plan
- [x] \`pnpm --filter @drawcast/mcp-server test\` (131 passing)
- [x] \`pnpm --filter drawcast-evals eval -- --id flow-login-01 --n 1\` before + after change
- [ ] Optional: n=3 baseline snapshot to confirm layout-axis shift statistically (not run here due to scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)