### PR TITLE
fix(core): offset parallel connectors so labels don't overlap

### DIFF
--- a/packages/core/src/compile/passes.ts
+++ b/packages/core/src/compile/passes.ts
@@ -3,11 +3,11 @@
 // grouping BOTH require positional emit to have registered primitives.
 // See docs/03 §15-31.
 
-import type { Scene } from '../primitives.js';
+import type { Connector, PrimitiveId, Scene } from '../primitives.js';
 import type { CompileContext } from './context.js';
 import { emitLabelBox } from '../emit/labelBox.js';
 import { emitSticky } from '../emit/sticky.js';
-import { emitConnector } from '../emit/connector.js';
+import { emitConnector, type ConnectorLane } from '../emit/connector.js';
 import { applyGroup } from '../emit/group.js';
 import { emitFrame, applyFrameChildren } from '../emit/frame.js';
 import { emitLine } from '../emit/line.js';
@@ -57,11 +57,55 @@ export function passPositional(scene: Scene, ctx: CompileContext): void {
 /**
  * Pass 2 — "Relational": emit connectors now that every bindable primitive
  * has a registry entry.
+ *
+ * Before emitting, we bucket connectors by their unordered endpoint pair so
+ * each emitter gets a {index, count} lane assignment. Parallel connectors
+ * (multiple edges between the same two shapes — including bidirectional
+ * pairs) are then offset perpendicular to the arrow direction so their lines
+ * and labels don't overlap in the exported scene.
  */
 export function passRelational(scene: Scene, ctx: CompileContext): void {
+  const connectors: Connector[] = [];
   for (const p of scene.primitives.values()) {
-    if (p.kind === 'connector') emitConnector(p, ctx);
+    if (p.kind === 'connector') connectors.push(p);
   }
+
+  const lanes = assignConnectorLanes(connectors);
+  for (const p of connectors) {
+    emitConnector(p, ctx, lanes.get(p.id));
+  }
+}
+
+function assignConnectorLanes(
+  connectors: readonly Connector[],
+): Map<PrimitiveId, ConnectorLane> {
+  const groups = new Map<string, Connector[]>();
+  for (const c of connectors) {
+    const key = pairKey(c);
+    if (key === null) continue;
+    const list = groups.get(key);
+    if (list) {
+      list.push(c);
+    } else {
+      groups.set(key, [c]);
+    }
+  }
+
+  const lanes = new Map<PrimitiveId, ConnectorLane>();
+  for (const list of groups.values()) {
+    if (list.length <= 1) continue;
+    list.forEach((c, index) => {
+      lanes.set(c.id, { index, count: list.length });
+    });
+  }
+  return lanes;
+}
+
+function pairKey(c: Connector): string | null {
+  const from = typeof c.from === 'string' ? c.from : null;
+  const to = typeof c.to === 'string' ? c.to : null;
+  if (from === null || to === null) return null;
+  return from < to ? `${from}\u0000${to}` : `${to}\u0000${from}`;
 }
 
 /**

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -28,6 +28,26 @@ import { normalizePoints } from './shared/points.js';
 // Matches Excalidraw 0.17.x's minimum gap from calculateFocusAndGap().
 const DEFAULT_GAP = 1;
 
+// Perpendicular spacing between parallel connectors sharing an endpoint pair.
+// Chosen to exceed typical label widths (~100px for short Korean/English
+// edge labels) because Excalidraw repositions bound arrow labels onto each
+// arrow's midpoint at render time — axis-offsets we store are ignored, so
+// the perpendicular arrow offset is the only way to separate labels.
+const PARALLEL_LANE_SPACING = 120;
+
+// Residual axis offset kept for non-bound scenarios (e.g. free Point→Point
+// connectors whose labels are not repositioned by Excalidraw's bound-text
+// logic). Safe to keep modest since the perpendicular offset does the heavy
+// lifting for the common shape-to-shape case.
+const PARALLEL_LABEL_AXIS_OFFSET = 0.15;
+
+export interface ConnectorLane {
+  /** 0-based index of this connector within its parallel group. */
+  index: number;
+  /** Total connectors sharing the same unordered endpoint pair. */
+  count: number;
+}
+
 function centerOfRecord(record: PrimitiveRecord): Point {
   return [record.bbox.x + record.bbox.w / 2, record.bbox.y + record.bbox.h / 2];
 }
@@ -102,6 +122,42 @@ function resolveCenter(
   return { center: centerOfRecord(record), record };
 }
 
+// Shift both endpoints perpendicular to the arrow direction so parallel
+// connectors between the same pair of shapes render on separate lines.
+// When `lane` is undefined or count<=1, the endpoints are returned unchanged.
+function applyLaneOffset(
+  start: Point,
+  end: Point,
+  lane: ConnectorLane | undefined,
+): [Point, Point] {
+  if (!lane || lane.count <= 1) return [start, end];
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  const len = Math.hypot(dx, dy);
+  if (len < 1) return [start, end];
+  // Symmetric lane positions around the centerline: 2 lanes -> ±spacing/2,
+  // 3 lanes -> -spacing, 0, +spacing, etc.
+  const offset = (lane.index - (lane.count - 1) / 2) * PARALLEL_LANE_SPACING;
+  if (offset === 0) return [start, end];
+  // Canonicalise the direction so opposite-direction connectors in the same
+  // pair derive the *same* perpendicular axis; otherwise a positive offset
+  // for one arrow and a negative offset for its reverse twin cancel out and
+  // both arrows land back on the centerline.
+  const [cdx, cdy] = canonicaliseDirection(dx, dy);
+  const nx = -cdy / len;
+  const ny = cdx / len;
+  return [
+    [start[0] + nx * offset, start[1] + ny * offset],
+    [end[0] + nx * offset, end[1] + ny * offset],
+  ];
+}
+
+function canonicaliseDirection(dx: number, dy: number): [number, number] {
+  if (dx > 0) return [dx, dy];
+  if (dx < 0) return [-dx, -dy];
+  return dy >= 0 ? [dx, dy] : [-dx, -dy];
+}
+
 function buildRawPoints(
   start: Point,
   end: Point,
@@ -165,7 +221,11 @@ function buildBinding(
   };
 }
 
-export function emitConnector(p: Connector, ctx: CompileContext): void {
+export function emitConnector(
+  p: Connector,
+  ctx: CompileContext,
+  lane?: ConnectorLane,
+): void {
   const style = resolveEdgeStyle(p.style, ctx.theme, p.id, ctx);
   const routing = p.routing ?? 'straight';
 
@@ -173,8 +233,9 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
   //    the boundary now because Excalidraw 0.17.x renders exactly these points.
   const fromRes = resolveCenter(p.from, ctx, p.id, 'from');
   const toRes = resolveCenter(p.to, ctx, p.id, 'to');
-  const start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
-  const end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
+  const rawStart = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
+  const rawEnd = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
+  const [start, end] = applyLaneOffset(rawStart, rawEnd, lane);
   const rawPoints = buildRawPoints(start, end, routing);
   const { points, width, height } = normalizePoints(rawPoints);
 
@@ -229,10 +290,29 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
     const fontSize = style.fontSize ?? ctx.theme.defaultFontSize;
     const lineHeight = getLineHeight(fontFamily);
     const metrics = measureText({ text: p.label, fontSize, fontFamily });
-    // Midpoint of the raw (pre-normalisation) points: visually unimportant
-    // because Excalidraw repositions bound arrow labels on first render.
-    const midX = (start[0] + end[0]) / 2;
-    const midY = (start[1] + end[1]) / 2;
+    // Midpoint of the (shifted) endpoints. For parallel connectors we also
+    // slide the label along the pair's *canonical* axis so opposite-direction
+    // labels don't land at identical coordinates (midpoint ± offset along
+    // each arrow's own direction cancels out — the two arrows share a
+    // midpoint). Using the canonical axis breaks that symmetry.
+    const mx = (start[0] + end[0]) / 2;
+    const my = (start[1] + end[1]) / 2;
+    const dxFull = end[0] - start[0];
+    const dyFull = end[1] - start[1];
+    const lenFull = Math.hypot(dxFull, dyFull);
+    let midX = mx;
+    let midY = my;
+    if (lane && lane.count > 1 && lenFull >= 1) {
+      const [cdx, cdy] = canonicaliseDirection(dxFull, dyFull);
+      const ux = cdx / lenFull;
+      const uy = cdy / lenFull;
+      const axisShift =
+        PARALLEL_LABEL_AXIS_OFFSET *
+        (lane.index - (lane.count - 1) / 2) *
+        lenFull;
+      midX = mx + ux * axisShift;
+      midY = my + uy * axisShift;
+    }
 
     const labelBase = baseElementFields({
       id: labelId,

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -161,6 +161,68 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     expect(arrow.endBinding?.elementId).toBe(rects[1]!.id);
   });
 
+  it('parallel connectors (bidirectional pair) are offset perpendicular so labels do not collide', () => {
+    // Two vertically-stacked rectangles with bidirectional connectors — the
+    // regression we observed: both arrows ran on the same line and both
+    // labels landed at identical midpoints. After the lane-offset fix the
+    // two arrows must sit on distinct parallel lines.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [200, 80],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 300],
+      fit: 'fixed',
+      size: [200, 80],
+      text: 'B',
+    };
+    const forward: Connector = {
+      kind: 'connector',
+      id: 'ab' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      label: 'req',
+      routing: 'straight',
+    };
+    const reverse: Connector = {
+      kind: 'connector',
+      id: 'ba' as PrimitiveId,
+      from: 'b' as PrimitiveId,
+      to: 'a' as PrimitiveId,
+      label: 'res',
+      routing: 'straight',
+    };
+    const result = compile(makeScene([a, b, forward, reverse]));
+    const arrows = result.elements.filter(
+      (el): el is ExcalidrawArrowElement => el.type === 'arrow',
+    );
+    expect(arrows).toHaveLength(2);
+    // The two arrows must have distinct x origins (perpendicular offset).
+    expect(arrows[0]!.x).not.toBe(arrows[1]!.x);
+
+    // Their label midpoints (== arrow midpoint since straight vertical) must
+    // also differ, otherwise both labels render on top of each other.
+    const labels = result.elements.filter(
+      (el) => el.type === 'text' && el.containerId !== undefined,
+    );
+    const arrowLabels = labels.filter(
+      (el) =>
+        'containerId' in el &&
+        arrows.some((a) => a.id === (el as { containerId?: string }).containerId),
+    );
+    expect(arrowLabels).toHaveLength(2);
+    const labelXs = arrowLabels.map((el) => el.x);
+    expect(labelXs[0]).not.toBe(labelXs[1]);
+  });
+
   it('raw Point endpoints are passed through unchanged (no boundary math)', () => {
     const c: Connector = {
       kind: 'connector',


### PR DESCRIPTION
## Summary
- Bidirectional (or otherwise parallel) connectors between the same pair of shapes previously rendered on top of each other with identical label midpoints. The eval harness's static Excalidraw export exposed the bug as a single illegible stack of labels.
- `passRelational` now buckets connectors by unordered endpoint pair, and `emitConnector` applies a perpendicular lane offset (with canonicalised direction so opposite-direction twins don't cancel out).
- Added regression test `parallel connectors (bidirectional pair) are offset perpendicular so labels do not collide` in `emit-connector.test.ts`.

## Evidence
`pnpm --filter drawcast-evals eval -- --id arch-3tier-01 --skip-rubric` on the `arch-3tier-01` golden question:

**Before** — the two HTTP edges and two DB edges stacked on the same lines with overlapping labels.
**After** — each of the four bidirectional edges renders on its own line with its own readable label.

## Test plan
- [x] `pnpm --filter @drawcast/core test` (70 passed, +1 regression)
- [x] `pnpm -r test` (267 passed across core/mcp-server/app)
- [x] Re-ran `arch-3tier-01` E2E and inspected the exported PNG — labels no longer overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Parallel connectors between the same elements now display with proper visual separation
  * Fixed label positioning to prevent overlapping text for multiple connectors between the same endpoints

* **Tests**
  * Added test coverage for bidirectional parallel connector rendering scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->