### PR TITLE
fix(core): port-aware elbow routing + Phase 2 layout engine design

### DIFF
--- a/docs/11-layout-engine.md
+++ b/docs/11-layout-engine.md
@@ -1,0 +1,975 @@
+<!-- status: DRAFT / 논의·합의용 초안 -->
+<!-- owner: TBD -->
+<!-- phase: Phase 2 (ELK 통합 + 하이브리드 계약) 주제 -->
+
+# 11. Layout Engine
+
+> **이 문서는 설계 제안서(draft)다.** 확정 API가 아니다. 사용자가 읽고 결정을 내리는 게 목표이며, 모든 인터페이스·알고리즘 선택은 "검토 후 확정" 상태다. 애매한 부분은 §10 오픈 퀘스천에 모았다.
+
+## 관련 문서
+
+- [`00-project-overview.md`](./00-project-overview.md) — MVP 범위
+- [`01-architecture.md`](./01-architecture.md) — 3-패키지 구조. Layout Engine은 `@drawcast/core` 내부 레이어로 들어갈 예정
+- [`02-l2-primitives.md`](./02-l2-primitives.md) — 본 문서의 스키마 변경 대상
+- [`03-compile-pipeline.md`](./03-compile-pipeline.md) — 현 3-pass compile. Layout pass를 그 사이에 끼울지, 앞에 둘지가 §4의 주제
+- [`05-mcp-server.md`](./05-mcp-server.md) — MCP tool 스키마 변경안(§5)
+- [`10-development-roadmap.md`](./10-development-roadmap.md) — Phase 7 "L3 Graph model + 자동 레이아웃" 항목이 본 문서의 씨앗
+
+---
+
+## 1. 배경과 동기
+
+### 1.1 현 구조의 한계
+
+현재 drawcast의 LLM(`claude -p ...`)은 `draw_upsert_box`·`draw_upsert_edge` 호출마다 **스스로 좌표를 계산**해서 `at: [x, y]` 를 채운다. `drawUpsertBox` 의 zod 스키마에서 `at` 은 `required` 이며, `size`도 `fit='fixed'` 일 때 필수다 (`packages/mcp-server/src/tools/drawUpsertBox.ts:109`).
+
+```ts
+// drawUpsertBox.ts:37-54 (요약)
+export const drawUpsertBoxInputSchema = z.object({
+  id: z.string().min(1),
+  at: PointSchema,          // ← 현재 필수
+  // ...
+  size: SizeSchema.optional(),
+  // ...
+});
+```
+
+이 계약은 **LLM이 공간 추론까지 떠안는다**는 뜻이다. 결과적으로:
+
+| 증상 | 원인 | 비용 |
+|---|---|---|
+| 노드 수가 늘수록 배치 품질 저하 | LLM의 2D 공간 추론은 noisy | 사용자 만족도 ↓ |
+| 다이어그램 타입마다 배치 규칙 프롬프트 누적 | flowchart vs tree vs architecture가 모두 다름 | `system-prompt.md` 분량 폭증 |
+| 엣지 라우팅이 노드 겹침/교차를 고려 못 함 | binding endpoint는 shape 경계 보정만 해줌 | 시각적 품질 ↓ |
+| 동일 요청에 다른 결과 | LLM 응답의 stochasticity가 좌표에 그대로 노출 | 예측 불가능 |
+
+### 1.2 증상: 엣지 라우팅 이상 동작
+
+Phase 1에서 `packages/core/src/emit/connector.ts` 에 **포트 인지 elbow 라우팅**을 도입했다 (cardinal N/E/S/W 포트 선택 + 방향 인지 꺾임). 이전에는 중심 벡터 기반 경계 교점이 코너 근처에 찍혀 elbow가 어색한 "위로 꺾임" 경로를 만들었다. Phase 1 이후 이 증상은 해결됐다.
+
+다만 Phase 1은 근본 해결이 아니다. `boundaryPoint`·`portPoint` 는 shape 경계까지만 안내할 뿐, **노드 사이 빈 공간을 지능적으로 통과**하거나 **다른 노드를 피해 돌아가는** 진짜 orthogonal routing은 아니다. LLM이 준 좌표가 노드 간격을 충분히 확보해주지 않으면 여전히 겹침·교차가 발생한다.
+
+결국 이 또한 **upstream에서 좌표 품질이 낮기 때문에 drown되는 하위 증상**이다. 본 문서가 제안하는 레이아웃 엔진(§3)이 좌표 품질 자체를 올리면 엣지 라우팅은 훨씬 단순한 문제가 된다.
+
+### 1.3 확장성 문제
+
+`00-project-overview.md` 와 `10-development-roadmap.md` 의 Phase 7에 "L3 Graph model + 자동 레이아웃"이 예약돼 있지만, MVP에서는 의도적으로 미뤘다. 지금은 아키텍처 다이어그램(BE/FE/Redis/AWS 같은 구성도), 시퀀스 다이어그램, 마인드맵 등을 LLM 프롬프트만으로 흉내 내려 하면 다음이 필요하다:
+
+- 타입별 배치 규칙 (mindmap은 radial, architecture는 layered 등)
+- 타입별 엣지 스타일 (sync/async/data flow)
+- 타입별 노드 아이콘 (AWS RDS, Redis, React 등)
+
+이걸 프롬프트로 주입하면 `system-prompt.md` 는 수천 줄이 되고, 그래도 LLM이 매번 정확히 따를 보장이 없다.
+
+### 1.4 결론
+
+**"LLM이 좌표를 만든다"**를 포기하고, **"LLM은 구조를 선언하고 엔진이 좌표를 만든다"** 로 전환한다. 이것이 본 문서가 제안하는 방향이다.
+
+---
+
+## 2. 설계 원칙
+
+### 2.1 구조 선언형 (semantic-first)
+
+LLM 출력은 **"노드가 뭐고, 어떻게 이어져 있는가"** 만 표현한다. 좌표·크기는 엔진이 결정.
+
+```
+현 상태:
+  LLM → [{ id: 'A', at: [100, 100] }, { id: 'B', at: [400, 100] }, ...]
+
+제안:
+  LLM → [{ id: 'A' }, { id: 'B' }, { edge: 'A → B' }]
+  Engine → [{ id: 'A', at: [x_A, y_A] }, { id: 'B', at: [x_B, y_B] }, ...]
+```
+
+### 2.2 하이브리드 (LLM 오버라이드 허용)
+
+LLM이 의도적으로 좌표/크기를 주면 **엔진은 그 의도를 존중**한다. 완전 자동이 아니라 **"기본은 자동, 명시하면 고정"**.
+
+- `at` 미지정 → 엔진이 배치
+- `at` 지정 → "이 노드는 여기 고정" 으로 엔진에 제약(constraint)으로 전달
+- 부분 지정(일부만 `at` 있음) → 지정된 것들 기준으로 나머지 배치
+
+이건 사용자가 수작업 편집 후 CLI에 "여기에 노드 하나 더 추가해줘" 라고 요청했을 때도 깨지지 않기 위한 안전장치다.
+
+### 2.3 계층 분리
+
+현 `03-compile-pipeline.md` 는 **(Primitive → Excalidraw element)** 가 한 덩어리다. 여기에 **Graph Model → Layout → Router → Primitive → Excalidraw** 로 층을 벌린다.
+
+각 층은 단방향으로 아래 층에 의존하며, 상위 층 테스트는 하위 층 없이도 가능하도록 인터페이스로 분리.
+
+### 2.4 결정적 렌더 (determinism)
+
+동일 입력 → 동일 출력. ELK 자체는 결정적이지만, seed·tie-breaking 규칙을 고정해서 "LLM이 노드 순서를 다르게 주면 레이아웃이 흔들린다"를 방지한다.
+
+- primitive insertion order가 ELK input에 일관되게 반영되도록 `SceneStore` 가 Map 대신 `Map + insertionOrder` 를 유지하거나, Graph Model 빌드 시 `id` 사전순 정렬 중 하나를 명시적으로 선택.
+- **TBD**: insertion order vs id sort — §10 참조.
+
+### 2.5 계약 안정성
+
+하위 호환이 최우선이다. 기존 `at` 기반 입력은 **Phase 2 이후에도 무기한 지원**한다. "optional" 로 만들 뿐 제거하지 않는다.
+
+---
+
+## 3. 레이아웃 엔진 선택
+
+### 3.1 후보 비교
+
+| 엔진 | 알고리즘 | 환경 | 라이선스 | 번들 크기 | 엣지 라우팅 | Nested/Compound |
+|---|---|---|---|---|---|---|
+| **ELK.js (elkjs)** | layered, force, mrtree, radial, disco, stress, rectpacking 등 | 순수 JS + WASM | EPL-2.0 | ~300KB(min+gz, 순수 JS) / ~200KB(WASM 래퍼) | orthogonal, polyline, splines | ○ (compound graphs) |
+| dagre | layered (Sugiyama) 전용 | 순수 JS | MIT | ~100KB | orthogonal만 | △ (subgraph 제한적) |
+| Graphviz WASM (@hpcc-js/wasm) | dot, neato, fdp 등 | WASM | MIT | ~1-2MB | spline | ○ |
+| cola.js (WebCoLa) | force-directed + constraint | 순수 JS | MIT | ~120KB | straight/spline | △ |
+
+**엣지 라우팅 주**: 본 표의 "orthogonal" 은 단순한 L-shape 이상을 의미한다. ELK는 노드를 우회하는 real orthogonal routing을 내장한다.
+
+### 3.2 ELK.js 선택 근거
+
+1. **Mermaid v10+ 채택 선례**. 실전에서 LLM 생성 다이어그램을 다루는 가장 큰 사용자가 이미 ELK로 이동했다. 기대되는 사례·버그가 이미 공개돼 있다.
+2. **알고리즘 다양성**. layered/force/mrtree/radial 등이 한 엔진 안에 있어서 **다이어그램 타입별로 ELK 옵션만 바꾸면** 되는 구조. 엔진 여러 개를 엮을 필요 없음.
+3. **orthogonal edge routing**. 노드 회피 라우팅이 기본 기능. Phase 1 핫픽스의 한계를 근본 해결.
+4. **compound graphs**. 아키텍처 다이어그램의 VPC/AZ/Subnet boundary (우리의 `Frame`) 를 **"nested children을 알고 있는 레이아웃"** 으로 처리. dagre의 subgraph 대비 월등.
+5. **라이선스**. EPL-2.0. 앱이 commercial 배포되어도 ELK 라이브러리 자체 수정 시에만 공개 의무 → 우리는 ELK를 **수정 없이 consume** 할 것이라 문제 없음.
+6. **번들 크기**. 순수 JS 버전 ~300KB (min+gz). Sidecar(Node)와 App(Tauri WebView) 양쪽에서 허용 범위. **(확정 전 실측 필요 — §10)**
+7. **두 환경 지원**. `@drawcast/core` 는 Node도 브라우저도 실행돼야 한다. ELK는 둘 다 된다 (WASM 또는 순수 JS).
+
+### 3.3 탈락 근거
+
+| 엔진 | 탈락 이유 |
+|---|---|
+| dagre | layered 전용. architecture/mindmap/radial 지원 불가. compound graph 약함. |
+| Graphviz WASM | 번들 크기 큼(1-2MB). WASM blob 로드/초기화 오버헤드. ELK 대비 JS 친화성 부족. |
+| cola.js | constraint 위주라 layered 품질이 ELK 대비 약함. 아키텍처 다이어그램 용도 맞지 않음. |
+
+### 3.4 보완 라이브러리
+
+ELK 단독으로 안 되는 케이스:
+
+- **Sequence diagram** — lifeline + activation bar 구조는 그래프 레이아웃이 아니라 **시간축 기반 템플릿**이 맞다. ELK 부적합. 커스텀 레이아웃 필요 (§6 참조).
+- **Hand-written freedraw / sketch** — 레이아웃 대상 아님. 기존대로 primitive가 `at` 을 갖고 pass-through.
+
+---
+
+## 4. 아키텍처 (계층 분리)
+
+### 4.1 현 파이프라인 (as-is)
+
+```mermaid
+flowchart LR
+  LLM[LLM] -->|draw_upsert_*| MCP[MCP Server]
+  MCP -->|Scene| CORE[core.compile]
+  subgraph CORE
+    P1[Pass 1: Positional] --> P2[Pass 2: Relational] --> P3[Pass 3: Grouping]
+  end
+  CORE -->|elements| XLD[Excalidraw JSON]
+```
+
+### 4.2 제안 파이프라인 (to-be)
+
+```mermaid
+flowchart LR
+  LLM[LLM] -->|structural tools| MCP[MCP Server]
+  MCP -->|Scene w/ graph| CORE[core]
+  subgraph CORE
+    GM[Graph Model Build] --> LE[Layout Engine ELK] --> ER[Edge Router] --> PE[Primitive Emitter]
+    PE --> P1[Pass 1] --> P2[Pass 2] --> P3[Pass 3]
+  end
+  CORE -->|elements| XLD[Excalidraw JSON]
+```
+
+**핵심 아이디어**: Layout/Router는 primitive 생성 **앞**에 온다. Layout 결과가 각 primitive의 `at`/`size` 를 채워 넣으면, 그 다음은 기존 3-pass 그대로 돌아간다. 기존 emit 함수는 **변경 없음**.
+
+### 4.3 각 계층의 책임
+
+| 계층 | 입력 | 출력 | 순수성 |
+|---|---|---|---|
+| **Graph Model Build** | `Scene` (primitives + 옵션) | `GraphModel` (nodes, edges, constraints) | 순수 |
+| **Layout Engine** | `GraphModel` | `LaidOutGraph` (각 node에 x,y,w,h) | ELK async (Promise) |
+| **Edge Router** | `LaidOutGraph` + 원본 primitives | 엣지별 `points[]` 경로 | 순수 |
+| **Primitive Emitter** | 보강된 `Scene` (좌표가 채워진) | 기존과 동일한 `Scene` | 순수 |
+
+**주의**: ELK는 Promise 기반이다. 현 `compile(scene)` 은 동기 함수. → 새 진입점 `compileAsync(scene)` 을 추가한다. 동기 버전은 LLM이 이미 좌표를 다 준 경우 / MVP 호환 경로에서 유지.
+
+### 4.4 Graph Model 스키마 (초안)
+
+```ts
+// packages/core/src/layout/graph.ts (신설 제안)
+
+/**
+ * ELK-inspired graph model. 아직 Excalidraw 좌표계는 모름.
+ * 레이아웃 알고리즘은 이 모델만 보고 좌표를 결정한다.
+ */
+export interface GraphModel {
+  id: string;
+  // 다이어그램 타입 (§6 매트릭스 참조). 'auto' 면 graph shape로 추정.
+  diagramType?: DiagramType;
+  // 루트 노드들. nested children 은 Node.children 에.
+  children: GraphNode[];
+  edges: GraphEdge[];
+  // 타입별 레이아웃 옵션 (ELK layoutOptions 와 호환)
+  layoutOptions?: Record<string, string>;
+}
+
+export interface GraphNode {
+  id: string;
+  /** 관련 primitive ids. 레이아웃 결과를 어느 primitive에 쓸지 안다. */
+  primitiveIds: readonly string[];
+  /** 노드 최소/힌트 크기. LLM이 사이즈를 줬거나 text measure로 구해진 값. */
+  width?: number;
+  height?: number;
+  /** 의도 고정. LLM이 at을 줬으면 이걸로 고정 제약 전달. */
+  fixedPosition?: { x: number; y: number };
+  /** kind: 아키텍처 다이어그램용 (AWS RDS, Redis 등). §7 참조. */
+  kind?: string;
+  /** Nested children (Frame → compound graph). */
+  children?: GraphNode[];
+  /** port 제약 (상단 입력, 하단 출력 등). §6 참조. */
+  ports?: GraphPort[];
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;       // GraphNode.id
+  target: string;       // GraphNode.id
+  /** 소스/타겟 port 지정 (선택). */
+  sourcePort?: string;
+  targetPort?: string;
+  /** 라우팅 힌트. 'orthogonal' | 'polyline' | 'splines' */
+  routing?: EdgeRouting;
+  /** protocol: 동기/비동기/데이터 흐름 (§7). */
+  protocol?: EdgeProtocol;
+}
+
+export interface GraphPort {
+  id: string;
+  side?: 'north' | 'east' | 'south' | 'west';
+}
+
+export type DiagramType =
+  | 'flowchart'
+  | 'sequence'      // ELK 부적합 → 커스텀 엔진
+  | 'er'
+  | 'mindmap'
+  | 'class'
+  | 'tree'
+  | 'architecture'
+  | 'auto';
+
+export type EdgeRouting = 'orthogonal' | 'polyline' | 'splines';
+
+export type EdgeProtocol =
+  | 'sync' | 'async' | 'stream' | 'batch' | 'data' | 'control';
+```
+
+### 4.5 Layout Engine 인터페이스
+
+```ts
+// packages/core/src/layout/engine.ts (신설 제안)
+
+export interface LayoutEngine {
+  layout(graph: GraphModel): Promise<LaidOutGraph>;
+}
+
+export interface LaidOutGraph extends GraphModel {
+  children: LaidOutNode[];
+  edges: LaidOutEdge[];
+}
+
+export interface LaidOutNode extends GraphNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  children?: LaidOutNode[];
+}
+
+export interface LaidOutEdge extends GraphEdge {
+  /** ELK가 내준 waypoint. Edge Router는 이걸 보완·개선. */
+  sections?: readonly {
+    startPoint: { x: number; y: number };
+    endPoint: { x: number; y: number };
+    bendPoints?: readonly { x: number; y: number }[];
+  }[];
+}
+
+// ELK 구현체
+export class ElkLayoutEngine implements LayoutEngine {
+  constructor(private elk: ELK, private defaults: ElkDefaults) {}
+  async layout(graph: GraphModel): Promise<LaidOutGraph> { /* ... */ }
+}
+```
+
+### 4.6 Edge Router 인터페이스
+
+ELK가 내준 `sections` 를 Connector primitive의 `points[]` 로 변환하는 어댑터. 필요하면 후처리(예: 모서리 둥글리기, 겹치는 label 회피)도 여기서.
+
+```ts
+// packages/core/src/layout/router.ts
+
+export interface EdgeRouter {
+  route(graph: LaidOutGraph): Map<ConnectorId, RoutedEdge>;
+}
+
+export interface RoutedEdge {
+  points: readonly Point[];       // Connector.points로 들어갈 값 (pre-normalize)
+  bindings: { start?: string; end?: string };  // primaryId
+}
+```
+
+MVP 구현은 **단순 pass-through**: ELK의 bend points 를 그대로 `points` 로 넘기고, 시작/끝만 `boundaryPoint` 로 보정. 기존 `connector.ts` 의 boundaryPoint 로직은 그대로 재사용한다.
+
+### 4.7 Primitive Emitter (기존 유지)
+
+레이아웃이 결정한 좌표를 primitive에 주입하면 기존 `compile()` 그대로 쓰면 된다. **이게 이 설계의 가장 큰 장점**이다: emit 레이어는 손댈 게 거의 없다.
+
+```ts
+// 개념 흐름:
+function compileAsync(scene: Scene): Promise<CompileResult> {
+  const graph = buildGraphModel(scene);              // §4.4
+  const laid = await layoutEngine.layout(graph);     // §4.5
+  const routed = edgeRouter.route(laid);             // §4.6
+  const enrichedScene = applyLayoutToScene(scene, laid, routed);
+  return compile(enrichedScene);                     // 기존 3-pass 재사용
+}
+```
+
+### 4.8 현 `03-compile-pipeline.md` 와의 연결
+
+`03-compile-pipeline.md` 의 3-pass 모델은 그대로 유지. 본 설계는 **그 앞에 "Pass 0: Layout"** 을 끼우는 형태다.
+
+```
+PASS 0 (신규): Graph Model build → ELK layout → Edge routing
+                → Scene에 at/size/points 주입
+PASS 1: Positional   (기존)
+PASS 2: Relational   (기존)
+PASS 3: Grouping     (기존)
+```
+
+---
+
+## 5. MCP 스키마 변경안
+
+### 5.1 `draw_upsert_box`: `at`/`size` optional
+
+**현 상태** (`packages/mcp-server/src/tools/drawUpsertBox.ts:37-54, :109`):
+
+```ts
+required: ['id', 'at']   // at이 필수
+```
+
+**제안**:
+
+```ts
+required: ['id']         // at 제거
+// at, size 모두 optional.
+// fit='fixed' + size 미지정 → 에러 (기존 유지)
+// at 미지정 → 엔진이 배치
+```
+
+### 5.2 `draw_upsert_edge`: 변경 없음
+
+이미 구조 선언형이다 (`from`/`to` 가 primitive id 또는 좌표). 좌표형 endpoint 는 §2.2의 "하이브리드" 원칙대로 존중.
+
+### 5.3 새 필드
+
+#### 5.3.1 `diagramType` — 어느 레벨에 둘지 (TBD)
+
+**선택지**:
+
+**(A) 세션/씬 단위**: `draw_set_diagram_type({ type: 'architecture' })` 같은 별도 tool, 또는 `SceneStore` 가 theme와 나란히 보관.
+   - 장점: 한 번만 설정. 모든 upsert 호출이 영향받음.
+   - 단점: 씬에 여러 다이어그램이 혼재하는 경우 표현 불가.
+
+**(B) upsert 호출 단위**: 매 `draw_upsert_box` 에 `diagramType` 필드.
+   - 장점: 노드 단위 세밀 제어.
+   - 단점: 매번 반복. LLM이 잊을 수 있음.
+
+**(C) Frame 단위**: `draw_upsert_frame` 에 `diagramType` 달고, Frame 내부 노드는 그 타입을 상속.
+   - 장점: 한 씬에 여러 다이어그램 공존 가능 (아키텍처 다이어그램 위 모서리에 시퀀스 다이어그램 등).
+   - 단점: Frame 없는 씬은?
+
+**현재 기울기**: **(A) + (C) 혼합**. 기본 `diagramType` 은 씬 레벨, Frame이 자체 `diagramType` 을 가지면 Frame 내부만 override. 최종 결정은 §10 오픈 퀘스천.
+
+#### 5.3.2 `kind` — 노드의 의미적 타입 (§7 참조)
+
+`LabelBox` 에 `kind?: string` 추가 제안.
+
+- 예: `'aws.rds'`, `'aws.ec2'`, `'redis'`, `'react'`, `'postgres'`, `'kafka'`, `'browser'`, `'user'`, …
+- 아이콘 레지스트리가 이 값으로 아이콘을 lookup. 모르는 값은 기본 도형.
+- LLM에게 "알려진 kind 목록" 을 tool description으로 제공.
+
+```ts
+// 제안 확장 (packages/core/src/primitives.ts)
+export interface LabelBox extends BaseProps {
+  kind: 'labelBox';          // discriminator (기존)
+  semanticKind?: string;     // ← 신설. 'aws.rds' 등
+  // ...
+}
+```
+
+**주의**: 기존 `kind: 'labelBox'` 는 discriminator. 새 필드는 충돌 피해 `semanticKind` 로. (이름은 bikeshed — `nodeType`, `role` 등 대안.)
+
+#### 5.3.3 `protocol` — 엣지의 의미 (§7 참조)
+
+`Connector` 에 `protocol?: EdgeProtocol` 추가 제안.
+
+- `sync` → 실선 + 일반 화살표
+- `async` → 점선 + 열린 화살표
+- `stream` → 굵은 선 + 더블 화살표
+- `data` → 얇은 선 + 점선 다이아몬드 헤드
+- ...
+
+테마 레이어(§4 `04-theme-system.md`)가 protocol → 스타일 매핑을 소유. LLM은 의미만 주고 스타일은 테마가 결정.
+
+### 5.4 마이그레이션 (하위 호환)
+
+| 입력 | Phase 1 | Phase 2 (ELK 도입 후) | Phase 3 |
+|---|---|---|---|
+| `at` 있음 | 그대로 배치 | 고정 제약으로 전달 | 동일 |
+| `at` 없음 | 에러 | 엔진이 자동 배치 | 동일 |
+| `diagramType` 없음 | — | `auto` (추정) | 동일 |
+| `kind` 없음 | — | 일반 도형 | 동일 |
+| `protocol` 없음 | — | 테마 기본 edge 스타일 | 동일 |
+
+**원칙**: 기존 입력은 **무조건 계속 동작**. 새 필드는 전부 optional.
+
+### 5.5 Tool description 변경
+
+`drawUpsertBox.ts:58-59` 의 `DESCRIPTION` 은 현재 "크기 자동, fit=fixed 시 명시" 만 안내한다. 제안:
+
+```
+Add or update a labeled box. Prefer to omit `at` — the layout engine will
+position it automatically based on edges. Pass `at` only when you explicitly
+want to override the layout (e.g., user asked to pin it). Same id re-applies
+as an update. Use `semanticKind` for architecture diagrams (e.g. 'aws.rds').
+```
+
+---
+
+## 6. 다이어그램 타입 매트릭스
+
+### 6.1 타입별 ELK 알고리즘 매핑
+
+| diagramType | ELK algorithm | 방향 | 주요 layoutOptions | 비고 |
+|---|---|---|---|---|
+| `flowchart` | `layered` | TB or LR | `nodePlacement.strategy=NETWORK_SIMPLEX`, `spacing.nodeNode=60` | 가장 검증된 조합. Mermaid flowchart도 이것. |
+| `tree` | `mrtree` | TB | `spacing.nodeNode=40` | 계층 트리 (조직도, 파일 트리). |
+| `mindmap` | `radial` | — | `radial.optimizationCriteria=WEDGE_COMPACTION` | 중심 루트, 방사형 확산. |
+| `class` | `layered` | TB | `elk.direction=DOWN`, `elk.edgeRouting=ORTHOGONAL` | 상속 관계. UML class. |
+| `er` | `force` or `stress` | — | `stress.dimension=XY` | 엔티티 관계. 대칭성 중요. |
+| `architecture` | `layered` + compound | LR | `elk.hierarchyHandling=INCLUDE_CHILDREN` | Frame nested graph가 핵심. §7. |
+| `sequence` | **(커스텀)** | — | — | ELK 부적합. 전용 레이아웃 필요. |
+| `auto` | **(휴리스틱)** | — | — | 그래프 shape 추정 (아래) |
+
+### 6.2 `auto` 추정 휴리스틱
+
+엣지의 연결 패턴을 보고 타입을 추정:
+
+```
+1. 단일 루트 + DAG → 'tree' (in-degree 0 노드 1개, 사이클 없음)
+2. 단일 루트 + 가지 많음 → 'mindmap' (자식이 radial 분포)
+3. DAG + 여러 소스·싱크 → 'flowchart'
+4. 사이클 있음 → 'flowchart' (layered가 처리)
+5. kind 필드에 'aws.*' 등 존재 → 'architecture'
+```
+
+이 추정은 실패해도 무방 (LLM이 명시적으로 `diagramType` 주면 override).
+
+### 6.3 Sequence diagram 특이 처리
+
+ELK로 시퀀스 다이어그램을 못 그리는 이유: 시퀀스는 **참가자가 위에 수평 배치되고, 메시지가 시간순으로 내려오는 lifeline** 구조다. 이건 그래프 레이아웃이 아니라 **시간축 기반 템플릿**.
+
+제안: **별도 CustomLayoutEngine** 을 플러그인 식으로 붙인다.
+
+```ts
+const layoutEngineByType: Record<DiagramType, LayoutEngine> = {
+  flowchart: elkLayoutEngine('layered'),
+  tree: elkLayoutEngine('mrtree'),
+  architecture: elkLayoutEngine('layered', { hierarchy: 'INCLUDE_CHILDREN' }),
+  sequence: sequenceLayoutEngine(),   // ← 커스텀
+  // ...
+};
+```
+
+`sequenceLayoutEngine` 은 Phase 3 또는 그 이후. MVP에서는 sequence는 미지원으로 두거나, 기존 LLM-좌표 경로로 fallback.
+
+### 6.4 다이어그램 타입별 예시 (개요)
+
+```mermaid
+flowchart TB
+  subgraph flowchart["flowchart — ELK layered TB"]
+    A1[입력] --> A2{검증} --> A3[저장]
+    A2 -->|실패| A4[에러]
+  end
+  subgraph mindmap["mindmap — ELK radial"]
+    M0[core] --- M1[UI]
+    M0 --- M2[API]
+    M0 --- M3[DB]
+  end
+  subgraph tree["tree — ELK mrtree"]
+    T1[root] --> T2[a] & T3[b]
+    T2 --> T4[a1] & T5[a2]
+  end
+```
+
+---
+
+## 7. 아키텍처 다이어그램 특화 설계
+
+### 7.1 목표 상
+
+사용자가 "우리 백엔드 구성도 그려줘 — Next.js FE, NestJS BE, Redis, Postgres (AWS RDS), S3, CloudFront" 라고 요청하면, 다음이 나와야 한다:
+
+- 각 노드가 **그 서비스의 공식 아이콘** 으로 표시
+- VPC / Subnet / AZ boundary 가 Frame으로 감싸짐
+- 엣지가 **프로토콜 별 스타일** (HTTPS 실선 / Redis 점선 / SQS async 등)
+- LLM은 **좌표 없이** 구조만 주면 엔진이 배치
+
+### 7.2 `semanticKind` + 아이콘 레지스트리
+
+```ts
+// packages/core/src/icons/registry.ts (신설 제안)
+
+export interface IconEntry {
+  semanticKind: string;                    // 'aws.rds'
+  displayName: string;                     // 'RDS'
+  provider?: string;                        // 'aws' | 'gcp' | ...
+  // 아이콘 소스 (복수 방안 — §7.3)
+  asset:
+    | { kind: 'svg-inline'; svg: string }
+    | { kind: 'dataurl'; dataURL: string; mimeType: string }
+    | { kind: 'ref'; url: string };        // lazy load (§7.4)
+  // 기본 크기(픽셀)
+  size: readonly [number, number];
+  // 시맨틱 힌트 (레이아웃 옵션)
+  shapeHint?: 'square' | 'cylinder' | 'hexagon';
+}
+
+export interface IconRegistry {
+  resolve(kind: string): IconEntry | undefined;
+  listKnownKinds(): readonly string[];
+}
+```
+
+emit 단계에서 `LabelBox` 의 `semanticKind` 가 존재하고 registry에 있으면:
+
+- 해당 아이콘을 `Image` primitive로 박스 내부에 포함 (또는 box의 배경)
+- 또는 별도 `Image` primitive를 생성하고 group으로 묶음
+
+**TBD**: 아이콘을 box 안에 embed 할지, 별개 image로 box 위에 overlay 할지 — §10.
+
+### 7.3 아이콘 세트 후보
+
+| 세트 | 범위 | 라이선스 | 포맷 | 번들? |
+|---|---|---|---|---|
+| AWS Architecture Icons | AWS 전용, ~600+ | AWS Trademark guidelines | SVG, PNG | 앱 번들 허용 (조건부) |
+| Devicon | 언어/프레임워크 (React, Vue, Django 등) | MIT | SVG | ○ |
+| Simple Icons | 브랜드 전반 (Slack, GitHub, AWS 등) | CC0 | SVG | ○ |
+| Cloud Provider Icons (Google) | GCP | Google Cloud Terms | SVG, PNG | 조건부 |
+| Mermaid architecture-beta icons | 기본 몇 개 | MIT | SVG | ○ |
+
+**제안**: 기본은 **Devicon + Simple Icons** (MIT/CC0로 가장 깔끔). AWS/GCP 아이콘은 **옵트인 플러그인**으로 제공. 라이선스 책임을 사용자에게 넘기지 않도록 **설치 시 모듈을 별도로 import** 하게 한다.
+
+```ts
+import { drawcastCore } from '@drawcast/core';
+import { awsIcons } from '@drawcast/icons-aws';  // opt-in
+
+drawcastCore.iconRegistry.register(awsIcons);
+```
+
+### 7.4 번들 vs CDN (결정 필요)
+
+- **번들**: 앱 크기 ↑ (아이콘 수백개). 오프라인 동작. 라이선스 간단.
+- **CDN lazy**: 첫 렌더 시 fetch. 오프라인 실패. CORS 주의.
+
+**기울기**: **번들 (SVG 인라인)**. SVG 하나당 1-5KB. 500개라도 1-2MB. MVP는 번들, 향후 lazy 옵션 고려.
+
+### 7.5 Nested Frame → Compound Graph
+
+현 `Frame` primitive는 `children: PrimitiveId[]` 를 가진다. ELK의 compound graph는 **부모 노드가 자식 노드를 포함하며 레이아웃이 자식까지 고려**하는 구조다. 자연스러운 1:1 매핑.
+
+```
+Frame('VPC')
+  ├── Frame('AZ-1a')
+  │   ├── LabelBox('ec2-1')
+  │   └── LabelBox('rds-1')
+  └── Frame('AZ-1b')
+      ├── LabelBox('ec2-2')
+      └── LabelBox('rds-2')
+```
+
+`elk.hierarchyHandling: INCLUDE_CHILDREN` 옵션을 주면 ELK가 자식 노드를 부모 경계 안에 배치하고, 부모 Frame 크기를 자식에 맞게 조정한다. 기존 `Frame.size` 는 optional 로 바꿔서 "없으면 자동" 처리.
+
+### 7.6 Edge `protocol` 스타일 매핑
+
+테마 레벨에서 정의:
+
+```ts
+// packages/core/src/theme.ts (확장 제안)
+export interface Theme {
+  // ... 기존
+  edgeProtocolStyles?: Record<EdgeProtocol, Partial<EdgeStyle>>;
+}
+
+const defaultProtocolStyles: Record<EdgeProtocol, Partial<EdgeStyle>> = {
+  sync:    { strokeStyle: 'solid',   strokeWidth: 2 },
+  async:   { strokeStyle: 'dashed',  strokeWidth: 2 },
+  stream:  { strokeStyle: 'solid',   strokeWidth: 3 },
+  batch:   { strokeStyle: 'dotted',  strokeWidth: 2 },
+  data:    { strokeStyle: 'solid',   strokeWidth: 1 },
+  control: { strokeStyle: 'dashed',  strokeWidth: 1 },
+};
+```
+
+### 7.7 예시 입력 → 기대 출력
+
+**입력 (LLM이 생성)**:
+
+```json
+[
+  { "tool": "draw_upsert_frame", "id": "vpc", "title": "VPC (10.0.0.0/16)",
+    "diagramType": "architecture", "children": ["web", "api", "db", "cache"] },
+  { "tool": "draw_upsert_box", "id": "user", "text": "User", "semanticKind": "user" },
+  { "tool": "draw_upsert_box", "id": "cf",   "text": "CloudFront", "semanticKind": "aws.cloudfront" },
+  { "tool": "draw_upsert_box", "id": "web",  "text": "Next.js", "semanticKind": "nextjs" },
+  { "tool": "draw_upsert_box", "id": "api",  "text": "NestJS",  "semanticKind": "nestjs" },
+  { "tool": "draw_upsert_box", "id": "db",   "text": "RDS",     "semanticKind": "aws.rds" },
+  { "tool": "draw_upsert_box", "id": "cache","text": "Redis",   "semanticKind": "redis" },
+  { "tool": "draw_upsert_edge", "id": "e1", "from": "user", "to": "cf",  "protocol": "sync" },
+  { "tool": "draw_upsert_edge", "id": "e2", "from": "cf",   "to": "web", "protocol": "sync" },
+  { "tool": "draw_upsert_edge", "id": "e3", "from": "web",  "to": "api", "protocol": "sync" },
+  { "tool": "draw_upsert_edge", "id": "e4", "from": "api",  "to": "db",  "protocol": "sync" },
+  { "tool": "draw_upsert_edge", "id": "e5", "from": "api",  "to": "cache","protocol": "async" }
+]
+```
+
+**기대 출력(개략적 Mermaid 표현)**:
+
+```mermaid
+flowchart LR
+  user((User))
+  cf[CloudFront]
+  subgraph vpc["VPC 10.0.0.0/16"]
+    web[Next.js]
+    api[NestJS]
+    db[(RDS)]
+    cache[(Redis)]
+  end
+  user --> cf --> web --> api
+  api --> db
+  api -.-> cache
+```
+
+실제 Excalidraw 씬에서는 각 노드가 공식 아이콘으로 표시되고, VPC Frame이 내부 노드들을 감싸며, `api → cache` 는 async 점선.
+
+---
+
+## 8. 시스템 프롬프트 변경
+
+### 8.1 현 상태 (`packages/app/src-tauri/resources/system-prompt.md`)
+
+현 system-prompt는 중의성 확인, 스코프, 레이블, 종료 조건, 노드 수 제한을 다룬다. **좌표 계산에 대한 명시적 지침은 없다**. LLM이 알아서 `at` 을 채우고 있는 상태.
+
+### 8.2 제안 변경 (Phase 2 진입 시)
+
+#### 8.2.1 섹션 추가: "좌표 계산 금지"
+
+```md
+[6] 좌표 규칙 (Phase 2 이후)
+- `at` 을 직접 계산하지 마라. 생략하면 레이아웃 엔진이 자동 배치한다.
+- 사용자가 명시적으로 "여기에 둬라", "고정해라" 라고 요청했을 때만 `at` 을 준다.
+- `size` 도 마찬가지. 텍스트에 맞춰 자동 fit이 기본.
+- 엣지의 `from`/`to` 는 반드시 primitive id로 지정한다. 좌표 [x, y] 는 사용하지 않는다 (포인팅 좌표가 필요한 극히 드문 경우 제외).
+```
+
+#### 8.2.2 섹션 추가: "다이어그램 타입 명시"
+
+```md
+[7] 다이어그램 타입
+- 사용자 요청이 명확한 타입을 시사하면 `diagramType` 을 지정한다.
+  - 플로우차트: 'flowchart' (기본)
+  - 조직도·파일트리·계층: 'tree'
+  - 마인드맵·브레인스토밍: 'mindmap'
+  - UML 클래스: 'class'
+  - ER 다이어그램: 'er'
+  - 시스템 아키텍처(AWS/GCP/인프라): 'architecture'
+- 확신이 없으면 `diagramType: 'auto'` 또는 생략.
+```
+
+#### 8.2.3 섹션 추가: "아키텍처 다이어그램 시 kind"
+
+```md
+[8] 아키텍처 다이어그램 (architecture 타입)
+- 노드가 알려진 서비스면 `semanticKind` 를 명시한다. 예:
+  - AWS: 'aws.ec2', 'aws.rds', 'aws.s3', 'aws.cloudfront', 'aws.sqs', ...
+  - 인프라: 'redis', 'postgres', 'mysql', 'kafka', 'nginx'
+  - 프레임워크: 'react', 'nextjs', 'vue', 'nestjs', 'django', 'rails'
+  - 기타: 'user', 'browser', 'mobile'
+- 알려진 kind가 아니면 생략(일반 박스).
+- VPC/AZ/Subnet 같은 경계는 `draw_upsert_frame` 으로 감싼다.
+- 엣지 `protocol` 로 의미를 표현한다: 'sync'(기본), 'async', 'stream', 'data', 'batch'.
+```
+
+#### 8.2.4 기존 섹션 수정
+
+`[5] 노드 수 제한` 은 유지하되, "좌표 계산 부담이 줄었으므로 초과 시 분할" 대신 "가독성 위해 분할" 로 톤 변경.
+
+### 8.3 Diff 초안 (개략)
+
+```diff
+ [1] 중의성 확인 (생성 전 단계)
+ ...
+ [5] 노드 수 제한
+-- 메인 다이어그램은 Miller's Law 에 따라 7 ± 2 노드를 목표로 한다.
+-- 초과할 경우 하위 프로세스별 서브 다이어그램으로 분할하거나, 프레임 도구(`draw_upsert_frame`)로 그룹화한다.
++- 메인 다이어그램은 7 ± 2 노드를 목표. 초과하면 의미 단위로 프레임으로 감싸거나 별도 다이어그램으로 분리.
++
++[6] 좌표 규칙
++- `at` 을 직접 계산하지 마라. 생략하면 레이아웃 엔진이 자동 배치한다.
++- 사용자가 명시적으로 위치를 지정한 경우에만 `at` 을 준다.
++
++[7] 다이어그램 타입
++- 요청 맥락에 맞는 `diagramType` 을 명시: flowchart / tree / mindmap / class / er / architecture.
++- 확신이 없으면 'auto'.
++
++[8] 아키텍처 다이어그램
++- 알려진 서비스는 `semanticKind` 로 표시 ('aws.rds', 'redis' 등).
++- 엣지 `protocol` 로 동기/비동기/데이터 흐름을 구분.
+```
+
+### 8.4 프롬프트 버전 관리
+
+`system-prompt.md` 는 파일 첫 줄에 version comment가 있다:
+
+```
+<!-- drawcast-system-prompt version: 1 (2026-04-21) -->
+```
+
+Phase 2 진입 시 **version: 2** 로 bump. Phase 3 도입 후 한 번 더.
+
+---
+
+## 9. 마이그레이션 전략
+
+### 9.1 Phase 순서
+
+```mermaid
+gantt
+  dateFormat  YYYY-MM-DD
+  title Layout Engine 도입 로드맵
+  section Phase 1 (완료)
+  엣지 라우팅 휴리스틱 핫픽스      :done, p1, 2026-04-20, 1d
+  section Phase 2 (본 문서 주제)
+  Graph Model + ELK 통합           :p2a, after p1, 14d
+  하이브리드 계약 (at optional)    :p2b, after p2a, 5d
+  evals/golden-set 갱신            :p2c, after p2b, 5d
+  section Phase 3
+  architecture 타입 + 아이콘 레지스트리 :p3a, after p2c, 10d
+  mindmap/tree/class/er 타입         :p3b, after p3a, 10d
+  section Phase 4 (보류)
+  sequence 커스텀 레이아웃          :p4, after p3b, 14d
+```
+
+### 9.2 Phase 2 세부 단계
+
+1. **Graph Model 타입 정의** (`packages/core/src/layout/graph.ts` 신설)
+2. **ELK 의존성 추가** (`elkjs`, Node/브라우저 양쪽 동작 검증)
+3. **LayoutEngine 구현** — 먼저 `flowchart` 하나만
+4. **`compileAsync` 진입점 추가** — 기존 `compile` 은 유지
+5. **MCP tool 스키마 `at` optional** — 단, MVP 호환을 위해 **행동 변경은 feature flag**
+   - 환경변수 `DRAWCAST_LAYOUT_ENGINE=elk` 로 오프/온 토글
+   - 기본 off (기존 behavior) → CI/evals 통과 확인 후 on
+6. **evals/golden-set 작성** — Phase 2 도입 전후 회귀 비교용
+7. **system-prompt 업데이트** — feature flag on 시점에 맞춰 version bump
+
+### 9.3 하위 호환 유지 기간
+
+- **영구 유지**: `at` 좌표 직접 지정 입력. Phase 7 이후라도 제거 계획 없음.
+- **Phase 3까지 유지**: `at` 미지정 시 기존 동작(naive grid 배치 등 fallback). Phase 3 이후는 ELK 없으면 에러.
+- **즉시 변경 가능**: 내부 primitive 구조, compile pipeline의 pass 개수 (사용자 계약 바깥).
+
+### 9.4 Evals/Golden-set 갱신 방침
+
+현 `evals/` 디렉토리(리포지토리 루트)에 있는 eval들:
+
+- LLM 호출 → 기대 primitive 집합 비교 (구조 체크)
+- compile 결과 → Excalidraw 로드 성공 (컴파일 가능성 체크)
+
+Phase 2 도입 시 추가:
+
+- **레이아웃 eval**: 동일 구조 입력 → 같은 상대 위치 (절대 좌표 아닌 위상) 검증
+- **좌표 독립성 eval**: `at` 없는 입력과 `at` 있는 입력의 최종 좌표 차이가 허용 범위 내
+- **시각 회귀 eval**: preview 이미지 스냅샷 diff (threshold 기반)
+
+### 9.5 롤백 계획
+
+ELK 통합 후 품질 저하 발견 시:
+
+1. Feature flag `DRAWCAST_LAYOUT_ENGINE=off` 로 기존 동작 복구
+2. system-prompt version을 직전으로 revert
+3. evals에서 회귀 확인 후 재시도
+
+**중요**: ELK 통합 PR은 **한 번에 다 바꾸지 않는다**. 최소 3개 PR로 쪼갠다:
+- PR A: 인터페이스·타입 정의 (런타임 변경 없음)
+- PR B: ELK 구현 (feature flag off 상태로 머지)
+- PR C: flag on + system-prompt 업데이트
+
+---
+
+## 10. 오픈 퀘스천 (결정 필요)
+
+> 아래는 "결정해야 하지만 아직 정하지 않은 것들". 본 문서 리뷰 과정에서 하나씩 합의.
+
+| # | 주제 | 선택지 | 기울기 |
+|---|---|---|---|
+| Q1 | ELK 배포 방식 | (a) 순수 JS / (b) WASM | JS 기울기 (단, 번들 실측 필요) |
+| Q2 | `diagramType` 범위 | (a) 씬 단위 / (b) 호출 단위 / (c) Frame 단위 혼합 | (a)+(c) 혼합 |
+| Q3 | 아이콘 번들 vs CDN | 번들 / CDN lazy | 번들 (MVP) |
+| Q4 | 아이콘 세트 기본 | Devicon / Simple Icons / AWS / 전체 | Devicon + Simple Icons 기본, AWS/GCP는 opt-in 플러그인 |
+| Q5 | Sequence 타입 지원 시점 | Phase 3 / Phase 4 / 보류 | Phase 4 (보류) |
+| Q6 | `semanticKind` 이름 | `semanticKind` / `nodeType` / `role` / `icon` / `category` / `tech` | TBD (bikeshed) — 짧은 쪽 선호 |
+| Q7 | Determinism: 순서 보장 | insertion order / id sort / LLM이 `order` 필드 명시 | insertion order 기울기 |
+| Q8 | `compile` 동기 유지? | 동기 보존 + `compileAsync` 추가 / `compile` 을 async로 교체 | 보존 + 추가 |
+| Q9 | feature flag 방식 | 환경변수 / SceneStore 옵션 / per-call 파라미터 | 환경변수 (MVP) |
+| Q10 | Protocol→스타일 매핑 위치 | `theme.ts` / `protocol-registry.ts` 별도 | theme.ts 확장 |
+| Q11 | ELK layoutOptions 노출 | LLM에 완전 hide / 고급 필드로 expose | hide (MVP) |
+| Q12 | 아이콘 크기와 box 크기 | 아이콘이 box 안에 embed / box 없이 image만 | TBD (UX 검토 필요) |
+| Q13 | Frame `size` optional 화 | yes (ELK가 계산) / no (기존대로 필수) | yes 기울기 |
+| Q14 | sequence-style timeline 은 Frame으로 대체? | 네/아니요 | TBD |
+
+각 질문은 별도 이슈/PR로 분리해서 합의하는 게 깨끗하다.
+
+---
+
+## 11. 작업 체크리스트 (Phase 2)
+
+> `10-development-roadmap.md` 의 체크리스트 스타일을 따른다. 본 체크리스트는 제안이며, 실제 실행 시 이슈로 쪼갤 것.
+
+### 11.1 설계 합의 (선행)
+
+- [ ] §10 오픈 퀘스천 각 항목 Q1~Q14 결정 (별도 이슈)
+- [ ] `semanticKind` 초기 어휘집 (~30-50개) 정의
+- [ ] 기본 아이콘 세트 결정 (Q3, Q4)
+
+### 11.2 의존성·스캐폴드
+
+- [ ] `elkjs` 의존성 추가 (`packages/core`)
+- [ ] ELK Node/브라우저 양쪽 환경 smoke test
+- [ ] 번들 크기 실측 (Tauri 프론트엔드 번들에 얹었을 때)
+
+### 11.3 Graph Model 레이어
+
+- [ ] `packages/core/src/layout/graph.ts` — 타입 정의
+- [ ] `packages/core/src/layout/buildGraphModel.ts` — Scene → GraphModel 변환
+  - [ ] primitive 순회, node/edge 매핑
+  - [ ] Frame nested 처리 (compound graph)
+  - [ ] `fixedPosition` 생성 (기존 `at` 있는 primitive)
+- [ ] 단위 테스트 — 엣지 없는 씬, 선형, 트리, 사이클, 중첩 Frame 각각
+
+### 11.4 Layout Engine 레이어
+
+- [ ] `packages/core/src/layout/engine.ts` — `LayoutEngine` 인터페이스
+- [ ] `packages/core/src/layout/elkEngine.ts` — ELK 구현
+  - [ ] flowchart (layered) 옵션
+  - [ ] tree (mrtree) 옵션
+  - [ ] mindmap (radial) 옵션
+  - [ ] architecture (layered + INCLUDE_CHILDREN) 옵션
+  - [ ] `fixedPosition` 제약 전달
+- [ ] 결정성 테스트 (동일 입력 → 동일 출력)
+- [ ] 성능 테스트 (노드 50개, 100개 기준 ms)
+
+### 11.5 Edge Router 레이어
+
+- [ ] `packages/core/src/layout/router.ts` — 인터페이스
+- [ ] ELK bend points → Connector points 변환
+- [ ] 기존 `boundaryPoint` 재사용해 시작/끝 보정
+- [ ] 모서리 둥글리기 (optional, MVP 이후)
+
+### 11.6 Primitive Emitter 통합
+
+- [ ] `packages/core/src/layout/applyToScene.ts` — 레이아웃 결과를 Scene에 주입
+- [ ] `compileAsync` 진입점 추가 (`packages/core/src/index.ts` export)
+- [ ] 기존 `compile` 동기 함수 유지 (하위 호환)
+
+### 11.7 MCP 스키마 변경
+
+- [ ] `drawUpsertBox` — `at` optional 화, zod required 변경
+- [ ] `drawUpsertBox` — `semanticKind` 필드 추가
+- [ ] `drawUpsertEdge` — `protocol` 필드 추가
+- [ ] `drawUpsertFrame` — `size` optional 화, `diagramType` 필드 추가
+- [ ] `draw_set_diagram_type` 신설 (Q2 결정에 따라)
+- [ ] Tool description 업데이트 (좌표 금지 문구)
+- [ ] MCP initialize response의 layout instructions 갱신 (`mcp-server` 기존 channel 활용)
+
+### 11.8 아이콘 레지스트리 (Phase 3 선행 가능)
+
+- [ ] `packages/core/src/icons/registry.ts` — 인터페이스
+- [ ] `packages/core/src/icons/builtin.ts` — Devicon + Simple Icons 초기 세트
+- [ ] `@drawcast/icons-aws` 별도 패키지 구조 스케치
+- [ ] emit 시 아이콘 주입 로직 (TBD — box 내부 embed vs overlay)
+
+### 11.9 System Prompt
+
+- [ ] version 2 bump (`packages/app/src-tauri/resources/system-prompt.md`)
+- [ ] [6]/[7]/[8] 섹션 추가
+- [ ] 기존 evals 통과 확인
+
+### 11.10 Feature flag + 점진적 활성
+
+- [ ] `DRAWCAST_LAYOUT_ENGINE` 환경변수 파싱
+- [ ] CI에서 on/off 양쪽 모드 각각 evals 실행
+- [ ] 앱 설정 UI (TBD — MVP에서는 환경변수만)
+
+### 11.11 Evals & Golden-set
+
+- [ ] 구조 동등성 eval — Phase 2 전/후 동일 요청의 primitive 집합 비교
+- [ ] 상대 위치 eval — 좌표는 다르되 위상이 같음
+- [ ] 시각 회귀 eval — preview PNG 스냅샷 (threshold 기반)
+- [ ] `evals/golden/` 디렉토리 구조 정의
+
+### 11.12 문서
+
+- [ ] `02-l2-primitives.md` — `semanticKind`, `protocol` 필드 추가
+- [ ] `03-compile-pipeline.md` — "Pass 0: Layout" 추가
+- [ ] `05-mcp-server.md` — 새 필드·새 tool 반영
+- [ ] `10-development-roadmap.md` — Phase 2/3 세부 갱신
+- [ ] 본 문서의 "status: DRAFT" 를 "ACCEPTED" 로 전환
+
+### 11.13 성공 기준 (Phase 2 DoD)
+
+- [ ] `at` 없이 5-노드 flowchart 요청 → 깔끔한 layered 결과
+- [ ] `at` 있는 노드 + 없는 노드 혼합 → 고정된 노드는 지정 좌표, 나머지는 주변 자동 배치
+- [ ] 기존 evals 전부 통과 (feature flag off)
+- [ ] 기존 evals 전부 통과 (feature flag on, golden-set 갱신 후)
+- [ ] 노드 100개 다이어그램 레이아웃 < 1초 (Node CI 환경 기준)
+- [ ] ELK 번들이 Tauri 앱 바이너리 크기 +2MB 이하
+
+---
+
+## 부록 A: 참고 링크 (웹 검증 필요)
+
+> 본 섹션의 URL/수치는 문서 작성 시점 기준 기억에 의존. PR 리뷰 전 재확인 요망.
+
+- ELK.js: https://github.com/kieler/elkjs
+- ELK 알고리즘 참조: https://eclipse.dev/elk/reference/algorithms.html
+- Mermaid v10 ELK 도입 공지: (실제 공지 URL 확인 TBD)
+- Devicon: https://devicon.dev/
+- Simple Icons: https://simpleicons.org/
+- AWS Architecture Icons: https://aws.amazon.com/architecture/icons/
+- 관련 논문: Eiglsperger et al., "Fast Layering Algorithms for Layered Graph Drawing" — Sugiyama 계열 레퍼런스
+
+## 부록 B: 용어 정리
+
+- **L2 primitive**: drawcast의 중간 표현. `LabelBox`, `Connector` 등. `02-l2-primitives.md`.
+- **L1 element**: Excalidraw 네이티브 element. `ExcalidrawElement[]`. `03-compile-pipeline.md`.
+- **Graph Model**: 본 문서에서 제안하는 새 레이어. primitive보다 한 단계 추상적이며 좌표 모름.
+- **Compound graph**: 노드가 자식 노드를 포함하는 그래프. ELK 용어. 우리 `Frame` 에 대응.
+- **Orthogonal routing**: 엣지를 수평/수직 선분만으로 구성, 노드를 회피. ELK 기본 옵션.
+- **semanticKind**: 본 문서에서 제안하는 노드의 의미적 타입 (AWS RDS, React 등). 이름은 TBD (Q6).
+
+## 부록 C: 변경 이력
+
+| 버전 | 날짜 | 변경 | 작성자 |
+|---|---|---|---|
+| 0.1 DRAFT | 2026-04-21 | 최초 초안 | (TBD) |

--- a/evals/package.json
+++ b/evals/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint runner --ext .ts"
   },
   "dependencies": {
+    "@drawcast/core": "workspace:*",
     "@excalidraw/excalidraw": "0.17.6",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "commander": "^12.1.0",

--- a/evals/runner/aggregate.ts
+++ b/evals/runner/aggregate.ts
@@ -32,6 +32,16 @@ export interface SummaryJson {
   total_runs: number;
   scored_runs: number;
   pass_rate: number;
+  /**
+   * Rubric pass AND zero structural overlap. Intended as the regression
+   * gate for layout-engine work: rubric verdict alone conflates rendering
+   * scale artifacts with real structural quality, and overlap_pairs=0
+   * alone tolerates unreadable layouts. Taking both lets a layout change
+   * only claim a win when it improves both axes at once.
+   */
+  strict_pass_rate: number;
+  /** Scenes whose nodes do not overlap at all. */
+  overlap_free_rate: number;
   by_axis: Record<RubricAxis, AxisStats>;
   by_category: Record<string, SummaryBucket>;
   by_difficulty: Record<string, SummaryBucket>;
@@ -53,12 +63,22 @@ export async function writeSummary(options: {
     .filter((failure): failure is { id: string; sample: number; reason: string } =>
       failure !== undefined,
     );
+  const passCount = scored.filter(
+    (result) => result.score.rubric.verdict === 'pass',
+  ).length;
+  const overlapFreeCount = scored.filter((result) => isOverlapFree(result.score.metrics)).length;
+  const strictPassCount = scored.filter(
+    (result) =>
+      result.score.rubric.verdict === 'pass' && isOverlapFree(result.score.metrics),
+  ).length;
   const summary: SummaryJson = {
     run_id: options.runId,
     total_questions: options.questions.length,
     total_runs: options.results.length,
     scored_runs: scored.length,
-    pass_rate: rate(scored.filter((result) => result.score.rubric.verdict === 'pass').length, scored.length),
+    pass_rate: rate(passCount, scored.length),
+    strict_pass_rate: rate(strictPassCount, scored.length),
+    overlap_free_rate: rate(overlapFreeCount, scored.length),
     by_axis: axisStats(scored.map((result) => result.score.rubric)),
     by_category: bucketBy(scored, (result) => result.question.category),
     by_difficulty: bucketBy(scored, (result) => result.question.difficulty),
@@ -95,6 +115,12 @@ function hasRubricScore(
   result: SampleResult,
 ): result is SampleResult & { score: ScoreArtifact & { rubric: RubricResult } } {
   return result.score?.rubric !== undefined;
+}
+
+function isOverlapFree(metrics: ScoreArtifact['metrics']): boolean {
+  // Missing metrics are treated as "not verifiably overlap-free" so the
+  // strict gate stays conservative on legacy results without the axis.
+  return metrics !== undefined && metrics.overlap_pairs === 0;
 }
 
 function axisStats(scores: readonly RubricResult[]): Record<RubricAxis, AxisStats> {
@@ -181,6 +207,8 @@ function renderSummaryMarkdown(summary: SummaryJson): string {
 - total_runs: ${summary.total_runs}
 - scored_runs: ${summary.scored_runs}
 - pass_rate: ${summary.pass_rate}
+- strict_pass_rate: ${summary.strict_pass_rate}
+- overlap_free_rate: ${summary.overlap_free_rate}
 - latency_p50_ms: ${summary.latency_p50_ms ?? 'n/a'}
 - latency_p95_ms: ${summary.latency_p95_ms ?? 'n/a'}
 

--- a/evals/runner/render.ts
+++ b/evals/runner/render.ts
@@ -5,7 +5,18 @@ import { chromium } from 'playwright';
 import type { ExcalidrawScene } from './types.js';
 
 const require = createRequire(import.meta.url);
-const MAX_RENDER_WIDTH = 1800;
+
+// Canvas safety cap. Beyond ~4096 we risk hitting browser texture limits
+// across GPUs; pick the next power-of-two under that. Any scene larger
+// than this still gets scaled down, but auto-layout output fits easily.
+const MAX_EXPORT_DIMENSION = 4096;
+
+// Lower bound on export scale. Below this, 16px text in Excalidraw lands
+// under ~8px in the PNG, which the Codex rubric reliably flags as a
+// readability failure regardless of the underlying structural quality.
+// Pin the floor so large scenes trade raw pixel count for legibility
+// instead of silently tanking the rubric.
+const MIN_FONT_SCALE = 0.5;
 
 function resolvePackageFile(pkgName: string, subPath: string): string {
   const pkgJson = require.resolve(`${pkgName}/package.json`);
@@ -32,7 +43,7 @@ export async function renderSceneToPng(
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage({
-      viewport: { width: MAX_RENDER_WIDTH, height: 1400 },
+      viewport: { width: 1800, height: 1400 },
       deviceScaleFactor: 1,
     });
     await page.setContent('<!doctype html><html><body></body></html>');
@@ -40,7 +51,7 @@ export async function renderSceneToPng(
     await page.addScriptTag({ path: reactDomPath });
     await page.addScriptTag({ path: bundlePath });
     const result = await page.evaluate(
-      async ({ inputScene, maxWidth }): Promise<BrowserRenderResult> => {
+      async ({ inputScene, maxDim, minFontScale }): Promise<BrowserRenderResult> => {
         const browserWindow = window as unknown as {
           ExcalidrawLib?: {
             exportToBlob?: (options: Record<string, unknown>) => Promise<Blob>;
@@ -67,7 +78,16 @@ export async function renderSceneToPng(
           quality: 1,
           exportPadding: 48,
           getDimensions: (width: number, height: number) => {
-            const scale = width > maxWidth ? maxWidth / width : 1;
+            // Scale down only when a dimension exceeds the canvas cap.
+            // If the fit-scale would crush text below the floor, clamp
+            // to minFontScale even if the result slightly exceeds maxDim
+            // — readability wins over raw pixel count.
+            const naturalScale = Math.min(
+              maxDim / width,
+              maxDim / height,
+              1,
+            );
+            const scale = Math.max(minFontScale, naturalScale);
             return {
               width: Math.ceil(width * scale),
               height: Math.ceil(height * scale),
@@ -79,7 +99,11 @@ export async function renderSceneToPng(
           bytes: Array.from(new Uint8Array(await blob.arrayBuffer())),
         };
       },
-      { inputScene: scene, maxWidth: MAX_RENDER_WIDTH },
+      {
+        inputScene: scene,
+        maxDim: MAX_EXPORT_DIMENSION,
+        minFontScale: MIN_FONT_SCALE,
+      },
     );
     await fs.writeFile(outputPath, Buffer.from(result.bytes));
   } finally {

--- a/evals/runner/scripts/layout-smoke.ts
+++ b/evals/runner/scripts/layout-smoke.ts
@@ -1,0 +1,120 @@
+// Render a fixed flowchart twice — with and without the Phase 2 layout
+// engine — and dump the two PNGs side by side. Useful as a manual "did
+// this actually improve things?" check that does not require running
+// the full Codex-rubric eval harness.
+//
+// Usage:
+//   pnpm -C evals build
+//   node evals/dist/runner/scripts/layout-smoke.js [outDir]
+//
+// Default outDir is /tmp/layout-smoke.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import {
+  compileAsync,
+  serializeAsExcalidrawFile,
+  sketchyTheme,
+  type Connector,
+  type LabelBox,
+  type Primitive,
+  type PrimitiveId,
+  type Scene,
+} from '@drawcast/core';
+import { renderSceneToPng } from '../render.js';
+import type { ExcalidrawScene } from '../types.js';
+
+function box(
+  id: string,
+  text: string,
+  shape: LabelBox['shape'] = 'rectangle',
+): LabelBox {
+  return {
+    kind: 'labelBox',
+    id: id as PrimitiveId,
+    shape,
+    text,
+    // No `at` — Phase 2 hybrid contract. ELK places the node; the
+    // sync-compile fallback plants it at the origin for comparison.
+  };
+}
+
+function edge(id: string, from: string, to: string, label?: string): Connector {
+  return {
+    kind: 'connector',
+    id: id as PrimitiveId,
+    from: from as PrimitiveId,
+    to: to as PrimitiveId,
+    routing: 'elbow',
+    ...(label !== undefined && { label }),
+  };
+}
+
+function buildLoginFlowchart(): Scene {
+  // Reconstruction of the user flowchart from the original PR conversation:
+  // Start -> email/password -> validate? -> (invalid) warning -> retry -> email
+  //                                   \-> (valid) auth -> auth_ok?
+  //                                          \-> (fail) error -> retry -> email
+  //                                          \-> (pass) success -> dashboard -> end
+  const primitives: Primitive[] = [
+    box('start', '시작', 'ellipse'),
+    box('email', '이메일 / 비밀번호 입력'),
+    box('validate', '입력값 검증', 'diamond'),
+    box('warning', '입력 오류 안내'),
+    box('auth', '서버 인증 요청'),
+    box('auth_ok', '인증 성공?', 'diamond'),
+    box('error', '오류 메시지 표시'),
+    box('success', '로그인 성공'),
+    box('dashboard', '대시보드 이동'),
+    box('end', '종료', 'ellipse'),
+    edge('e1', 'start', 'email'),
+    edge('e2', 'email', 'validate'),
+    edge('e3', 'validate', 'warning', '무효'),
+    edge('e4', 'warning', 'email', '재입력'),
+    edge('e5', 'validate', 'auth', '유효'),
+    edge('e6', 'auth', 'auth_ok'),
+    edge('e7', 'auth_ok', 'error', '실패'),
+    edge('e8', 'error', 'email', '재시도'),
+    edge('e9', 'auth_ok', 'success', '성공'),
+    edge('e10', 'success', 'dashboard'),
+    edge('e11', 'dashboard', 'end'),
+  ];
+  return {
+    primitives: new Map(primitives.map((p) => [p.id, p])),
+    theme: sketchyTheme,
+  };
+}
+
+async function renderTo(
+  scene: Scene,
+  outPath: string,
+  useLayout: boolean,
+): Promise<void> {
+  const compiled = await compileAsync(scene, { useLayout });
+  const envelope = serializeAsExcalidrawFile(compiled);
+  // `serializeAsExcalidrawFile` returns an Excalidraw-compatible envelope
+  // whose element array matches the ExcalidrawScene the render module
+  // accepts; cast rather than re-shape so we do not lose metadata.
+  await renderSceneToPng(envelope as unknown as ExcalidrawScene, outPath);
+}
+
+async function main(): Promise<void> {
+  const outDir = process.argv[2] ?? '/tmp/layout-smoke';
+  await fs.mkdir(outDir, { recursive: true });
+
+  const scene = buildLoginFlowchart();
+  const beforePath = path.join(outDir, 'before.png');
+  const afterPath = path.join(outDir, 'after.png');
+
+  process.stdout.write(`[1/2] rendering BEFORE (useLayout=false) ... `);
+  await renderTo(scene, beforePath, false);
+  process.stdout.write('done\n');
+
+  process.stdout.write(`[2/2] rendering AFTER  (useLayout=true)  ... `);
+  await renderTo(scene, afterPath, true);
+  process.stdout.write('done\n');
+
+  process.stdout.write(`\nWrote:\n  ${beforePath}\n  ${afterPath}\n`);
+}
+
+await main();

--- a/packages/app/src-tauri/resources/system-prompt.md
+++ b/packages/app/src-tauri/resources/system-prompt.md
@@ -1,4 +1,4 @@
-<!-- drawcast-system-prompt version: 1 (2026-04-21) -->
+<!-- drawcast-system-prompt version: 2 (2026-04-21) -->
 <!-- Appended to the Claude CLI's default system prompt via `--append-system-prompt`. -->
 <!-- Source of truth; bump the version line above whenever behaviour-facing lines change. -->
 
@@ -26,3 +26,9 @@
 [5] 노드 수 제한
 - 메인 다이어그램은 Miller's Law 에 따라 7 ± 2 노드를 목표로 한다.
 - 초과할 경우 하위 프로세스별 서브 다이어그램으로 분할하거나, 프레임 도구(`draw_upsert_frame`)로 그룹화한다.
+
+[6] 좌표 계산 금지
+- `at` 은 사용자가 "여기에 두라"·"고정" 같은 명시적 위치 요구를 한 경우에만 넘긴다. 그 외에는 **생략**하라. 레이아웃 엔진이 자동으로 배치한다.
+- 좌표를 직접 계산해 넣지 마라. LLM이 숫자 좌표를 만드는 순간 노드 간격·겹침·대칭이 무너진다.
+- 마찬가지로 `size` 도 필요한 경우에만 지정한다. 기본은 텍스트 자동 맞춤.
+- 엣지의 `from`/`to` 는 반드시 노드 id로 지정한다. 좌표 `[x, y]` 형태는 floating annotation 에만 쓰고, 일반 엣지엔 쓰지 마라.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
@@ -20,6 +22,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "elkjs": "^0.11.1",
     "lodash-es": "^4.17.21",
     "nanoid": "^5.0.7"
   },

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -75,6 +75,49 @@ function boundaryPoint(record: PrimitiveRecord, ctx: CompileContext, towards: Po
   return rotatePoint([center[0] + dx * t, center[1] + dy * t], center, element.angle);
 }
 
+type PortDir = 'N' | 'E' | 'S' | 'W';
+
+// Major-axis heuristic: connector leaves the side that points most directly
+// at the other node's centre. Ties (|dx| == |dy|) fall to horizontal so the
+// layout stays stable for grid-aligned pairs.
+function selectPortDirs(
+  fromCenter: Point,
+  toCenter: Point,
+): { fromDir: PortDir; toDir: PortDir } {
+  const dx = toCenter[0] - fromCenter[0];
+  const dy = toCenter[1] - fromCenter[1];
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0 ? { fromDir: 'E', toDir: 'W' } : { fromDir: 'W', toDir: 'E' };
+  }
+  return dy >= 0 ? { fromDir: 'S', toDir: 'N' } : { fromDir: 'N', toDir: 'S' };
+}
+
+// Anchor point at the centre of a cardinal side, rotation-aware. Diamond
+// and ellipse land on the corresponding vertex / axis end, which reads
+// cleanly as a connector anchor.
+function portPoint(record: PrimitiveRecord, ctx: CompileContext, dir: PortDir): Point {
+  const element = ctx.getElementById(record.primaryId)!;
+  const center = centerOfRecord(record);
+  const halfW = record.bbox.w / 2;
+  const halfH = record.bbox.h / 2;
+  let local: Point;
+  switch (dir) {
+    case 'E':
+      local = [center[0] + halfW, center[1]];
+      break;
+    case 'W':
+      local = [center[0] - halfW, center[1]];
+      break;
+    case 'S':
+      local = [center[0], center[1] + halfH];
+      break;
+    case 'N':
+      local = [center[0], center[1] - halfH];
+      break;
+  }
+  return rotatePoint(local, center, element.angle);
+}
+
 interface ResolvedEndpointCenter {
   center: Point;
   /** Non-null only when the endpoint references a bindable primitive. */
@@ -106,13 +149,39 @@ function buildRawPoints(
   start: Point,
   end: Point,
   routing: 'straight' | 'elbow' | 'curved',
+  startDir?: PortDir,
 ): Point[] {
   if (routing === 'elbow') {
-    const midX = (start[0] + end[0]) / 2;
+    // Horizontal-first when the connector leaves an E/W port so the first
+    // segment extends outward from the side; vertical-first for N/S ports.
+    // Without a hint (point endpoints) pick the longer axis: this matches
+    // the old behaviour for wide pairs and fixes the thin-tall case where
+    // the forced (midX, startY) kink used to overshoot the source node.
+    const horizontalFirst = startDir
+      ? startDir === 'E' || startDir === 'W'
+      : Math.abs(end[0] - start[0]) >= Math.abs(end[1] - start[1]);
+    if (horizontalFirst) {
+      // Axis-aligned: degenerate to a straight 2-point line so Excalidraw
+      // doesn't render a visible kink on top of coincident points.
+      if (Math.abs(start[1] - end[1]) < 1e-6) {
+        return [[start[0], start[1]], [end[0], end[1]]];
+      }
+      const midX = (start[0] + end[0]) / 2;
+      return [
+        [start[0], start[1]],
+        [midX, start[1]],
+        [midX, end[1]],
+        [end[0], end[1]],
+      ];
+    }
+    if (Math.abs(start[0] - end[0]) < 1e-6) {
+      return [[start[0], start[1]], [end[0], end[1]]];
+    }
+    const midY = (start[1] + end[1]) / 2;
     return [
       [start[0], start[1]],
-      [midX, start[1]],
-      [midX, end[1]],
+      [start[0], midY],
+      [end[0], midY],
       [end[0], end[1]],
     ];
   }
@@ -171,11 +240,24 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
 
   // 1) Endpoints -> scene-coordinate points. Bound references are anchored to
   //    the boundary now because Excalidraw 0.17.x renders exactly these points.
+  //    Elbow routing snaps to cardinal ports (side midpoints) so the first
+  //    kink extends out of a side rather than a corner. Straight/curved keep
+  //    the centre-to-centre boundary hit for visual balance on diagonals.
   const fromRes = resolveCenter(p.from, ctx, p.id, 'from');
   const toRes = resolveCenter(p.to, ctx, p.id, 'to');
-  const start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
-  const end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
-  const rawPoints = buildRawPoints(start, end, routing);
+  let start: Point;
+  let end: Point;
+  let startDir: PortDir | undefined;
+  if (routing === 'elbow' && fromRes.record && toRes.record) {
+    const dirs = selectPortDirs(fromRes.center, toRes.center);
+    start = portPoint(fromRes.record, ctx, dirs.fromDir);
+    end = portPoint(toRes.record, ctx, dirs.toDir);
+    startDir = dirs.fromDir;
+  } else {
+    start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
+    end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
+  }
+  const rawPoints = buildRawPoints(start, end, routing, startDir);
   const { points, width, height } = normalizePoints(rawPoints);
 
   // 2) Bindings

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -243,21 +243,36 @@ export function emitConnector(p: Connector, ctx: CompileContext): void {
   //    Elbow routing snaps to cardinal ports (side midpoints) so the first
   //    kink extends out of a side rather than a corner. Straight/curved keep
   //    the centre-to-centre boundary hit for visual balance on diagonals.
+  //
+  //    When the primitive carries a `routedPath` we skip all of that: it
+  //    means an external layout engine (ELK) already produced a waypoint
+  //    sequence that avoids node bodies. Using the built-in elbow math on
+  //    top would re-introduce the node-crossing regression the router
+  //    was picked to prevent.
   const fromRes = resolveCenter(p.from, ctx, p.id, 'from');
   const toRes = resolveCenter(p.to, ctx, p.id, 'to');
   let start: Point;
   let end: Point;
-  let startDir: PortDir | undefined;
-  if (routing === 'elbow' && fromRes.record && toRes.record) {
-    const dirs = selectPortDirs(fromRes.center, toRes.center);
-    start = portPoint(fromRes.record, ctx, dirs.fromDir);
-    end = portPoint(toRes.record, ctx, dirs.toDir);
-    startDir = dirs.fromDir;
+  let rawPoints: Point[];
+  if (p.routedPath !== undefined && p.routedPath.length >= 2) {
+    const first = p.routedPath[0]!;
+    const last = p.routedPath[p.routedPath.length - 1]!;
+    start = [first[0], first[1]];
+    end = [last[0], last[1]];
+    rawPoints = p.routedPath.map((pt) => [pt[0], pt[1]] as Point);
   } else {
-    start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
-    end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
+    let startDir: PortDir | undefined;
+    if (routing === 'elbow' && fromRes.record && toRes.record) {
+      const dirs = selectPortDirs(fromRes.center, toRes.center);
+      start = portPoint(fromRes.record, ctx, dirs.fromDir);
+      end = portPoint(toRes.record, ctx, dirs.toDir);
+      startDir = dirs.fromDir;
+    } else {
+      start = fromRes.record ? boundaryPoint(fromRes.record, ctx, toRes.center) : fromRes.center;
+      end = toRes.record ? boundaryPoint(toRes.record, ctx, fromRes.center) : toRes.center;
+    }
+    rawPoints = buildRawPoints(start, end, routing, startDir);
   }
-  const rawPoints = buildRawPoints(start, end, routing, startDir);
   const { points, width, height } = normalizePoints(rawPoints);
 
   // 2) Bindings

--- a/packages/core/src/emit/labelBox.ts
+++ b/packages/core/src/emit/labelBox.ts
@@ -107,11 +107,17 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
   }
 
   // -- Shape element -----------------------------------------------------------
+  // `at` is optional since Phase 2: when the primitive arrived without
+  // explicit coordinates the scene origin is a safe fallback — either
+  // the layout engine already rewrote `at` in compileAsync, or the
+  // caller is on the sync path and accepts origin placement as an
+  // explicit signal that they forgot.
+  const [atX, atY] = p.at ?? [0, 0];
   const shapeId = newElementId();
   const commonBase: BaseElementFields = baseElementFields({
     id: shapeId,
-    x: p.at[0] - width / 2,
-    y: p.at[1] - height / 2,
+    x: atX - width / 2,
+    y: atY - height / 2,
     width,
     height,
     angle: degreesToRadians(p.angle ?? 0),
@@ -215,8 +221,8 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
     elementIds: textId ? [shapeId, textId] : [shapeId],
     primaryId: shapeId,
     bbox: {
-      x: p.at[0] - width / 2,
-      y: p.at[1] - height / 2,
+      x: atX - width / 2,
+      y: atY - height / 2,
       w: width,
       h: height,
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,3 +59,27 @@ export {
   type ComplianceReport,
   type ComplianceCode,
 } from './testing/compliance.js';
+
+// Layout engine (Phase 2, Node-only). Gated behind DRAWCAST_LAYOUT_ENGINE.
+export {
+  compileAsync,
+  type CompileAsyncOptions,
+  ElkLayoutEngine,
+  type ElkLayoutEngineOptions,
+  buildGraphModel,
+  type BuildGraphModelOptions,
+  applyLayoutToScene,
+  type DiagramType,
+  type EdgeProtocol,
+  type EdgeRouting,
+  type GraphEdge,
+  type GraphModel,
+  type GraphNode,
+  type GraphPort,
+  type LaidOutEdge,
+  type LaidOutEdgeSection,
+  type LaidOutGraph,
+  type LaidOutNode,
+  type LayoutEngine,
+  type PortSide,
+} from './layout/index.js';

--- a/packages/core/src/layout/applyLayoutToScene.ts
+++ b/packages/core/src/layout/applyLayoutToScene.ts
@@ -1,11 +1,19 @@
-// Apply laid-out coordinates back onto the Scene's primitives. The output
-// is a fresh Scene with updated labelBoxes; everything else passes through
-// untouched so the existing emit layer (including the Phase 1 port-aware
-// elbow routing in connector.ts) sees the same primitive shape it would
-// on the synchronous compile path.
+// Apply laid-out coordinates back onto the Scene's primitives. Two
+// updates flow out of the layout pass:
+//
+//   - labelBox nodes receive new `at` + `size` so the emitted shape
+//     lands where ELK placed it.
+//   - connectors receive `routedPath` (from ELK edge sections) so the
+//     emit layer renders the engine-computed polyline instead of
+//     re-deriving one via port selection + elbow math. Without this
+//     step ELK's node-avoiding routing is thrown away and the Phase 1
+//     built-in router reintroduces through-node edges.
+//
+// Everything else passes through untouched so sync compile output on
+// the Tauri path is identical when the flag is off.
 
-import type { LabelBox, Primitive, Scene } from '../primitives.js';
-import type { LaidOutGraph, LaidOutNode } from './engine.js';
+import type { LabelBox, Point, Primitive, PrimitiveId, Scene } from '../primitives.js';
+import type { LaidOutEdge, LaidOutGraph, LaidOutNode } from './engine.js';
 
 export function applyLayoutToScene(scene: Scene, laid: LaidOutGraph): Scene {
   const updated = new Map<Primitive['id'], Primitive>(scene.primitives);
@@ -23,6 +31,18 @@ export function applyLayoutToScene(scene: Scene, laid: LaidOutGraph): Scene {
   };
   walk(laid.children);
 
+  for (const edge of laid.edges) {
+    // GraphEdge.id is a plain string from the graph layer; the Scene's
+    // Map keys are brand-typed PrimitiveId, but the value originated
+    // from a Connector we already own, so the cast is safe.
+    const edgeId = edge.id as PrimitiveId;
+    const primitive = updated.get(edgeId);
+    if (primitive === undefined || primitive.kind !== 'connector') continue;
+    const path = toRoutedPath(edge);
+    if (path === null) continue;
+    updated.set(edgeId, { ...primitive, routedPath: path });
+  }
+
   return { ...scene, primitives: updated };
 }
 
@@ -37,4 +57,28 @@ function applyToLabelBox(primitive: LabelBox, node: LaidOutNode): LabelBox {
     fit: 'fixed',
     size: [node.width, node.height],
   };
+}
+
+/**
+ * Flatten an ELK edge into a Connector.routedPath polyline.
+ *
+ * ELK supplies one ElkEdgeSection per edge for flat graphs (multi-
+ * section output is reserved for compound hierarchies Phase 3 will
+ * enable). A section carries a start point, an end point, and an
+ * optional bendPoints array — stitch them in order.
+ */
+function toRoutedPath(edge: LaidOutEdge): readonly Point[] | null {
+  const sections = edge.sections;
+  if (sections === undefined || sections.length === 0) return null;
+  const first = sections[0]!;
+  const points: Point[] = [[first.startPoint.x, first.startPoint.y]];
+  for (const section of sections) {
+    if (section.bendPoints !== undefined) {
+      for (const bend of section.bendPoints) {
+        points.push([bend.x, bend.y]);
+      }
+    }
+    points.push([section.endPoint.x, section.endPoint.y]);
+  }
+  return points;
 }

--- a/packages/core/src/layout/applyLayoutToScene.ts
+++ b/packages/core/src/layout/applyLayoutToScene.ts
@@ -1,0 +1,40 @@
+// Apply laid-out coordinates back onto the Scene's primitives. The output
+// is a fresh Scene with updated labelBoxes; everything else passes through
+// untouched so the existing emit layer (including the Phase 1 port-aware
+// elbow routing in connector.ts) sees the same primitive shape it would
+// on the synchronous compile path.
+
+import type { LabelBox, Primitive, Scene } from '../primitives.js';
+import type { LaidOutGraph, LaidOutNode } from './engine.js';
+
+export function applyLayoutToScene(scene: Scene, laid: LaidOutGraph): Scene {
+  const updated = new Map<Primitive['id'], Primitive>(scene.primitives);
+
+  const walk = (nodes: readonly LaidOutNode[]): void => {
+    for (const node of nodes) {
+      for (const primitiveId of node.primitiveIds) {
+        const primitive = updated.get(primitiveId);
+        if (primitive === undefined) continue;
+        if (primitive.kind !== 'labelBox') continue;
+        updated.set(primitiveId, applyToLabelBox(primitive, node));
+      }
+      if (node.children !== undefined) walk(node.children);
+    }
+  };
+  walk(laid.children);
+
+  return { ...scene, primitives: updated };
+}
+
+function applyToLabelBox(primitive: LabelBox, node: LaidOutNode): LabelBox {
+  // LabelBox.at is a center point (see emit/labelBox.ts:217-218) while
+  // ELK reports node origin as the top-left; translate before assigning.
+  // Pin size via fit='fixed' so downstream text measurement keeps the
+  // laid-out dimensions instead of re-fitting to the inner label.
+  return {
+    ...primitive,
+    at: [node.x + node.width / 2, node.y + node.height / 2],
+    fit: 'fixed',
+    size: [node.width, node.height],
+  };
+}

--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -1,0 +1,99 @@
+// Scene -> GraphModel translator. Phase 2 scope is flat flowchart graphs
+// only: every LabelBox becomes a GraphNode, every bound Connector becomes
+// a GraphEdge, and every other primitive kind is ignored by the layout
+// layer so its `at`/`size` stay untouched after layout.
+//
+// Frames are intentionally a skip trigger. The compound-graph translation
+// (Frame -> nested `children` + `elk.hierarchyHandling: INCLUDE_CHILDREN`)
+// lands in Phase 3 along with the architecture diagram preset. Until then
+// we do not want partial support to silently rearrange Frame-bound nodes
+// out of their container, so `buildGraphModel` reports null and the
+// caller falls back to the synchronous compile path.
+
+import type { Primitive, Scene } from '../primitives.js';
+import type { GraphEdge, GraphModel, GraphNode } from './graph.js';
+
+export interface BuildGraphModelOptions {
+  /** When true (default) a scene that contains any Frame is treated as
+   *  out-of-scope and the function returns null. Phase 3 flips this. */
+  skipIfFrame?: boolean;
+  /** Scene id passed through to ELK for deterministic logging. */
+  id?: string;
+}
+
+export function buildGraphModel(
+  scene: Scene,
+  options: BuildGraphModelOptions = {},
+): GraphModel | null {
+  const skipIfFrame = options.skipIfFrame ?? true;
+  const primitives = [...scene.primitives.values()];
+
+  if (skipIfFrame && primitives.some((p) => p.kind === 'frame')) {
+    return null;
+  }
+
+  const nodes: GraphNode[] = [];
+  const nodeIds = new Set<string>();
+  const edges: GraphEdge[] = [];
+
+  for (const primitive of primitives) {
+    if (primitive.kind === 'labelBox') {
+      const node = labelBoxToNode(primitive);
+      nodes.push(node);
+      nodeIds.add(node.id);
+    }
+  }
+
+  for (const primitive of primitives) {
+    if (primitive.kind === 'connector') {
+      const edge = connectorToEdge(primitive, nodeIds);
+      if (edge !== null) edges.push(edge);
+    }
+  }
+
+  return {
+    id: options.id ?? 'scene',
+    diagramType: 'flowchart',
+    children: nodes,
+    edges,
+  };
+}
+
+function labelBoxToNode(
+  primitive: Extract<Primitive, { kind: 'labelBox' }>,
+): GraphNode {
+  const node: GraphNode = {
+    id: primitive.id,
+    primitiveIds: [primitive.id],
+  };
+  // Measured size takes priority; without it ELK falls back to engine
+  // defaults (DEFAULT_NODE_WIDTH/HEIGHT) which loosely match the
+  // labelBox auto-fit output from Phase 1.
+  if (primitive.size !== undefined) {
+    node.width = primitive.size[0];
+    node.height = primitive.size[1];
+  }
+  return node;
+}
+
+function connectorToEdge(
+  primitive: Extract<Primitive, { kind: 'connector' }>,
+  knownNodeIds: ReadonlySet<string>,
+): GraphEdge | null {
+  // Only id-bound connectors participate. Raw Point endpoints are for
+  // floating annotation arrows and must not influence layered layout.
+  if (typeof primitive.from !== 'string' || typeof primitive.to !== 'string') {
+    return null;
+  }
+  // Dropping dangling edges keeps ELK from blowing up on unknown ids;
+  // the emit layer already warns on orphan references so we stay quiet.
+  if (!knownNodeIds.has(primitive.from) || !knownNodeIds.has(primitive.to)) {
+    return null;
+  }
+  return {
+    id: primitive.id,
+    source: primitive.from,
+    target: primitive.to,
+    routing: 'orthogonal',
+  };
+}

--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -73,6 +73,18 @@ function labelBoxToNode(
     node.width = primitive.size[0];
     node.height = primitive.size[1];
   }
+  // An explicit `at` is the LLM's (or user's) positional intent — pass
+  // it to ELK as a fixed-position hint so the layer algorithm tries to
+  // respect it. `at` is centre-based; ELK expects top-left, so we need
+  // a size to translate and skip the hint otherwise. Layered treats
+  // `elk.position` as a soft hint today; Phase 3 will introduce the
+  // interactive/fixed algorithm for hard pinning.
+  if (primitive.at !== undefined && primitive.size !== undefined) {
+    node.fixedPosition = {
+      x: primitive.at[0] - primitive.size[0] / 2,
+      y: primitive.at[1] - primitive.size[1] / 2,
+    };
+  }
   return node;
 }
 

--- a/packages/core/src/layout/compileAsync.ts
+++ b/packages/core/src/layout/compileAsync.ts
@@ -1,0 +1,58 @@
+// Phase 2: Node/MCP context only.
+// Async entry point that runs the layout pipeline ahead of the existing
+// synchronous compile. `compile()` stays as the canonical sync path —
+// this wraps it so the Tauri WebView can keep consuming pre-laid scenes
+// without pulling in elkjs. See docs/11-layout-engine.md §9.5.
+
+import { compile } from '../compile/index.js';
+import type { CompileResult } from '../compile/context.js';
+import type { Scene } from '../primitives.js';
+import { applyLayoutToScene } from './applyLayoutToScene.js';
+import { buildGraphModel } from './buildGraphModel.js';
+import { ElkLayoutEngine } from './elkEngine.js';
+import type { LayoutEngine } from './engine.js';
+
+export interface CompileAsyncOptions {
+  /** Force the layout pass on or off. When undefined the runtime reads
+   *  `DRAWCAST_LAYOUT_ENGINE` from `process.env`. */
+  useLayout?: boolean;
+  /** Inject a custom engine (mostly for tests and per-diagram presets). */
+  engine?: LayoutEngine;
+}
+
+export async function compileAsync(
+  scene: Scene,
+  options: CompileAsyncOptions = {},
+): Promise<CompileResult> {
+  const useLayout = options.useLayout ?? isLayoutEnabledFromEnv();
+  if (!useLayout) {
+    return compile(scene);
+  }
+
+  const graph = buildGraphModel(scene);
+  // Scene either fell outside layout scope (frame present) or had no
+  // layout-eligible primitives; preserve the legacy behaviour.
+  if (graph === null || graph.children.length === 0) {
+    return compile(scene);
+  }
+
+  const engine = options.engine ?? new ElkLayoutEngine();
+  const laid = await engine.layout(graph);
+  const enrichedScene = applyLayoutToScene(scene, laid);
+  return compile(enrichedScene);
+}
+
+/** True when the env var is explicitly opted-in. Accessed through
+ *  `globalThis` so this module stays compilable without `@types/node`
+ *  — the Tauri WebView imports this package as well and must not
+ *  force a Node-typed global surface. Browser contexts have no
+ *  `process` and therefore default the flag off, which is exactly
+ *  the Phase 2 posture. */
+function isLayoutEnabledFromEnv(): boolean {
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  if (proc?.env === undefined) {
+    return false;
+  }
+  const value = proc.env.DRAWCAST_LAYOUT_ENGINE;
+  return value === 'on' || value === '1' || value === 'true';
+}

--- a/packages/core/src/layout/compileAsync.ts
+++ b/packages/core/src/layout/compileAsync.ts
@@ -42,17 +42,26 @@ export async function compileAsync(
   return compile(enrichedScene);
 }
 
-/** True when the env var is explicitly opted-in. Accessed through
- *  `globalThis` so this module stays compilable without `@types/node`
- *  — the Tauri WebView imports this package as well and must not
- *  force a Node-typed global surface. Browser contexts have no
- *  `process` and therefore default the flag off, which is exactly
- *  the Phase 2 posture. */
+/** Resolve the layout flag with a Node-default-on, browser-default-off
+ *  posture. Accessed through `globalThis` so this module stays
+ *  compilable without `@types/node` — the Tauri WebView imports this
+ *  package too and must not force a Node-typed global surface.
+ *
+ *  - No `process` (e.g. Tauri WebView): always false. The UI layer
+ *    still renders via the sync `compile` path and never pulls in
+ *    the ELK binding.
+ *  - Node with no env var set: true. MCP server and evals opt in
+ *    by default now that Commit #7 flipped the gate.
+ *  - Node with `DRAWCAST_LAYOUT_ENGINE=off|0|false`: false. Explicit
+ *    escape hatch for debugging or rollback without a code change. */
 function isLayoutEnabledFromEnv(): boolean {
   const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
   if (proc?.env === undefined) {
     return false;
   }
   const value = proc.env.DRAWCAST_LAYOUT_ENGINE;
-  return value === 'on' || value === '1' || value === 'true';
+  if (value === 'off' || value === '0' || value === 'false') {
+    return false;
+  }
+  return true;
 }

--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -1,0 +1,225 @@
+// Phase 2: Node/MCP context only.
+// Consumers: `@drawcast/mcp-server` when composing a scene, and `drawcast-evals`
+// when regenerating baselines. The Tauri WebView must NOT reach this file;
+// it receives the already-laid-out scene via IPC and paints it with the
+// legacy synchronous `compile`. See docs/11-layout-engine.md §9.5 for the
+// rationale — Web Worker / Tauri Web Worker resolution is out of scope until
+// Phase 3 introduces in-app re-layout.
+
+import ElkConstructor, {
+  type ELK,
+  type ElkEdgeSection,
+  type ElkExtendedEdge,
+  type ElkNode,
+  type ElkPoint,
+  type ElkPort,
+  type LayoutOptions,
+} from 'elkjs/lib/elk.bundled.js';
+
+import type {
+  DiagramType,
+  GraphEdge,
+  GraphModel,
+  GraphNode,
+  GraphPort,
+} from './graph.js';
+import type {
+  LaidOutEdge,
+  LaidOutEdgeSection,
+  LaidOutGraph,
+  LaidOutNode,
+  LayoutEngine,
+} from './engine.js';
+
+/** Default bounding box used when a node arrives without measured size.
+ *  Picked to roughly match the Phase 1 LabelBox "auto-fit" output so
+ *  ELK spacing values tune similarly. */
+const DEFAULT_NODE_WIDTH = 160;
+const DEFAULT_NODE_HEIGHT = 60;
+
+/** Map diagram archetype -> ELK algorithm. `sequence` still falls to
+ *  `layered` in Phase 2 since a time-axis layout is deferred to Phase 4
+ *  per the roadmap; keeping the mapping total means `auto` never hits
+ *  an undefined branch. */
+const ALGORITHM_BY_TYPE: Record<DiagramType, string> = {
+  flowchart: 'layered',
+  tree: 'mrtree',
+  mindmap: 'radial',
+  class: 'layered',
+  er: 'stress',
+  architecture: 'layered',
+  sequence: 'layered',
+  auto: 'layered',
+};
+
+/** Baseline layout options. Values kept as strings because ELK's JSON
+ *  options dict expects strings regardless of the underlying numeric
+ *  type. `elk.randomSeed` pins determinism per docs §2.4. */
+const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
+  'elk.algorithm': 'layered',
+  'elk.direction': 'DOWN',
+  'elk.spacing.nodeNode': '60',
+  'elk.layered.spacing.nodeNodeBetweenLayers': '60',
+  'elk.edgeRouting': 'ORTHOGONAL',
+  'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+  'elk.randomSeed': '1',
+};
+
+export interface ElkLayoutEngineOptions {
+  /** Overrides layered onto DEFAULT_LAYOUT_OPTIONS for every call. Per-
+   *  call options passed via `GraphModel.layoutOptions` override these. */
+  layoutOptions?: LayoutOptions;
+  /** Injected for tests. Defaults to a fresh `elkjs` instance. */
+  elk?: ELK;
+}
+
+export class ElkLayoutEngine implements LayoutEngine {
+  private readonly elk: ELK;
+  private readonly defaults: LayoutOptions;
+
+  constructor(options: ElkLayoutEngineOptions = {}) {
+    this.elk = options.elk ?? new ElkConstructor();
+    this.defaults = { ...DEFAULT_LAYOUT_OPTIONS, ...(options.layoutOptions ?? {}) };
+  }
+
+  async layout(graph: GraphModel): Promise<LaidOutGraph> {
+    const algorithm = ALGORITHM_BY_TYPE[graph.diagramType ?? 'auto'];
+    const layoutOptions: LayoutOptions = {
+      ...this.defaults,
+      'elk.algorithm': algorithm,
+      ...(graph.layoutOptions ?? {}),
+    };
+
+    const rootNode: ElkNode = {
+      id: graph.id,
+      layoutOptions,
+      children: graph.children.map(toElkNode),
+      edges: graph.edges.map(toElkEdge),
+    };
+
+    const result = await this.elk.layout(rootNode);
+    return fromElkResult(graph, result);
+  }
+}
+
+function toElkNode(node: GraphNode): ElkNode {
+  const elk: ElkNode = {
+    id: node.id,
+    width: node.width ?? DEFAULT_NODE_WIDTH,
+    height: node.height ?? DEFAULT_NODE_HEIGHT,
+  };
+  if (node.fixedPosition !== undefined) {
+    elk.x = node.fixedPosition.x;
+    elk.y = node.fixedPosition.y;
+    elk.layoutOptions = {
+      'elk.position': `(${node.fixedPosition.x},${node.fixedPosition.y})`,
+    };
+  }
+  if (node.children !== undefined) {
+    elk.children = node.children.map(toElkNode);
+  }
+  if (node.ports !== undefined) {
+    elk.ports = node.ports.map(toElkPort);
+  }
+  return elk;
+}
+
+function toElkPort(port: GraphPort): ElkPort {
+  const elk: ElkPort = { id: port.id };
+  if (port.side !== undefined) {
+    elk.layoutOptions = { 'elk.port.side': port.side.toUpperCase() };
+  }
+  return elk;
+}
+
+function toElkEdge(edge: GraphEdge): ElkExtendedEdge {
+  return {
+    id: edge.id,
+    sources: [edge.sourcePort ?? edge.source],
+    targets: [edge.targetPort ?? edge.target],
+  };
+}
+
+function fromElkResult(original: GraphModel, result: ElkNode): LaidOutGraph {
+  const originalNodes = flattenGraphNodes(original.children);
+  const originalEdges = new Map(original.edges.map((edge) => [edge.id, edge]));
+
+  const laidOut: LaidOutGraph = {
+    ...original,
+    children: (result.children ?? []).map((child) => hydrateNode(child, originalNodes)),
+    edges: (result.edges ?? []).map((edge) => hydrateEdge(edge, originalEdges)),
+  };
+  return laidOut;
+}
+
+function flattenGraphNodes(nodes: readonly GraphNode[]): Map<string, GraphNode> {
+  const map = new Map<string, GraphNode>();
+  const walk = (list: readonly GraphNode[]): void => {
+    for (const node of list) {
+      map.set(node.id, node);
+      if (node.children !== undefined) walk(node.children);
+    }
+  };
+  walk(nodes);
+  return map;
+}
+
+function hydrateNode(
+  elkNode: ElkNode,
+  originals: Map<string, GraphNode>,
+): LaidOutNode {
+  const original = originals.get(elkNode.id);
+  if (original === undefined) {
+    throw new Error(
+      `ELK returned node "${elkNode.id}" that was absent from the input graph`,
+    );
+  }
+  // Strip `children` before spreading: the original's children are
+  // unlaid `GraphNode[]`, which `exactOptionalPropertyTypes` refuses
+  // to widen into `LaidOutNode[]` even though the overwrite below
+  // would replace the value entirely.
+  const { children: _unlaidChildren, ...rest } = original;
+  const laidOut: LaidOutNode = {
+    ...rest,
+    x: elkNode.x ?? 0,
+    y: elkNode.y ?? 0,
+    width: elkNode.width ?? DEFAULT_NODE_WIDTH,
+    height: elkNode.height ?? DEFAULT_NODE_HEIGHT,
+  };
+  if (elkNode.children !== undefined) {
+    laidOut.children = elkNode.children.map((child) => hydrateNode(child, originals));
+  }
+  return laidOut;
+}
+
+function hydrateEdge(
+  elkEdge: ElkExtendedEdge,
+  originals: Map<string, GraphEdge>,
+): LaidOutEdge {
+  const original = originals.get(elkEdge.id);
+  if (original === undefined) {
+    throw new Error(
+      `ELK returned edge "${elkEdge.id}" that was absent from the input graph`,
+    );
+  }
+  const laidOut: LaidOutEdge = { ...original };
+  if (elkEdge.sections !== undefined) {
+    laidOut.sections = elkEdge.sections.map(toLaidOutSection);
+  }
+  return laidOut;
+}
+
+function toLaidOutSection(section: ElkEdgeSection): LaidOutEdgeSection {
+  const out: LaidOutEdgeSection = {
+    startPoint: clonePoint(section.startPoint),
+    endPoint: clonePoint(section.endPoint),
+  };
+  if (section.bendPoints !== undefined) {
+    out.bendPoints = section.bendPoints.map(clonePoint);
+  }
+  return out;
+}
+
+function clonePoint(point: ElkPoint): { x: number; y: number } {
+  return { x: point.x, y: point.y };
+}

--- a/packages/core/src/layout/engine.ts
+++ b/packages/core/src/layout/engine.ts
@@ -1,0 +1,44 @@
+// LayoutEngine contract — the boundary every algorithm implementation
+// (ELK, custom sequence, future Graphviz binding) must satisfy. The
+// contract is purely async because ELK is async-only on browser and
+// `compileAsync` funnels everything through this interface; synchronous
+// consumers must stay on the legacy `compile` path.
+//
+// This file intentionally ships interfaces only. The first implementation
+// (ElkLayoutEngine) lands in a follow-up commit so the type-level
+// scaffolding can be reviewed in isolation.
+
+import type { GraphEdge, GraphModel, GraphNode } from './graph.js';
+
+export interface LaidOutNode extends GraphNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  children?: LaidOutNode[];
+}
+
+/** A single rectilinear segment of a routed edge. Origin matches ELK's
+ *  `ElkEdgeSection`: one segment is usually enough, with bend points
+ *  spelling out the corners of an orthogonal path. */
+export interface LaidOutEdgeSection {
+  startPoint: { x: number; y: number };
+  endPoint: { x: number; y: number };
+  bendPoints?: readonly { x: number; y: number }[];
+}
+
+export interface LaidOutEdge extends GraphEdge {
+  sections?: readonly LaidOutEdgeSection[];
+}
+
+export interface LaidOutGraph extends GraphModel {
+  children: LaidOutNode[];
+  edges: LaidOutEdge[];
+}
+
+export interface LayoutEngine {
+  /** Run layout. Must be pure w.r.t. input — two calls with an identical
+   *  `GraphModel` return equivalent geometry, so results can be cached
+   *  and regressions diffed. */
+  layout(graph: GraphModel): Promise<LaidOutGraph>;
+}

--- a/packages/core/src/layout/graph.ts
+++ b/packages/core/src/layout/graph.ts
@@ -1,0 +1,88 @@
+// Graph model — an Excalidraw-agnostic representation of "nodes and their
+// relations" that layout engines can consume without knowing how the result
+// will be rendered. Mirrors ELK's vocabulary (children, edges, ports,
+// layoutOptions) so the first engine binding in engine.ts can translate
+// directly without an intermediate shape.
+//
+// Kept intentionally structural: nothing here imports from ./emit/ or
+// ./compile/. Primitive ids flow through `primitiveIds` so the layout
+// result can be applied back to a Scene without the layout layer needing
+// to understand Connector/LabelBox/Frame semantics.
+
+import type { PrimitiveId } from '../primitives.js';
+
+/** Supported diagram archetypes. Each maps to a preferred ELK algorithm
+ *  (see engine.ts). `auto` asks the engine to guess from graph shape. */
+export type DiagramType =
+  | 'flowchart'
+  | 'tree'
+  | 'mindmap'
+  | 'class'
+  | 'er'
+  | 'architecture'
+  | 'sequence'
+  | 'auto';
+
+/** Edge path style hint. ELK maps these to `elk.edgeRouting` option values. */
+export type EdgeRouting = 'orthogonal' | 'polyline' | 'splines';
+
+/** Semantic edge protocol. Theme maps these to concrete stroke styles
+ *  (solid/dashed/width). Added here so the graph layer stays decoupled
+ *  from any theme implementation. */
+export type EdgeProtocol =
+  | 'sync'
+  | 'async'
+  | 'stream'
+  | 'batch'
+  | 'data'
+  | 'control';
+
+/** Cardinal port sides. Matches ELK `port.side`. */
+export type PortSide = 'north' | 'east' | 'south' | 'west';
+
+export interface GraphPort {
+  id: string;
+  side?: PortSide;
+}
+
+export interface GraphNode {
+  id: string;
+  /** Back-pointer to the source primitives. Populated when this node was
+   *  built from a Scene so `applyLayoutToScene` can find what to update. */
+  primitiveIds: readonly PrimitiveId[];
+  /** Layout hint / measured size. When omitted the engine defaults to
+   *  configured node spacing. */
+  width?: number;
+  height?: number;
+  /** If set, the engine treats this node as positionally locked — i.e.
+   *  the scene primitive arrived with an explicit `at`. */
+  fixedPosition?: { x: number; y: number };
+  /** Semantic kind (e.g. 'aws.rds', 'redis'). Consumed by architecture
+   *  diagrams for icon lookup and edge-style defaults. */
+  kind?: string;
+  /** Nested compound graph. Maps to Frame-bound primitives in the Scene. */
+  children?: GraphNode[];
+  ports?: GraphPort[];
+}
+
+export interface GraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourcePort?: string;
+  targetPort?: string;
+  routing?: EdgeRouting;
+  protocol?: EdgeProtocol;
+}
+
+export interface GraphModel {
+  /** Scene-level id. Not user-visible; exists so a single process can
+   *  keep multiple pending layouts straight. */
+  id: string;
+  diagramType?: DiagramType;
+  children: GraphNode[];
+  edges: GraphEdge[];
+  /** Free-form ELK overrides. Documented downstream; kept open here so
+   *  future algorithm additions don't require a type change. */
+  layoutOptions?: Record<string, string>;
+}

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -16,3 +16,5 @@ export type {
   LaidOutNode,
   LayoutEngine,
 } from './engine.js';
+
+export { ElkLayoutEngine, type ElkLayoutEngineOptions } from './elkEngine.js';

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -1,0 +1,18 @@
+export type {
+  DiagramType,
+  EdgeProtocol,
+  EdgeRouting,
+  GraphEdge,
+  GraphModel,
+  GraphNode,
+  GraphPort,
+  PortSide,
+} from './graph.js';
+
+export type {
+  LaidOutEdge,
+  LaidOutEdgeSection,
+  LaidOutGraph,
+  LaidOutNode,
+  LayoutEngine,
+} from './engine.js';

--- a/packages/core/src/layout/index.ts
+++ b/packages/core/src/layout/index.ts
@@ -18,3 +18,7 @@ export type {
 } from './engine.js';
 
 export { ElkLayoutEngine, type ElkLayoutEngineOptions } from './elkEngine.js';
+
+export { buildGraphModel, type BuildGraphModelOptions } from './buildGraphModel.js';
+export { applyLayoutToScene } from './applyLayoutToScene.js';
+export { compileAsync, type CompileAsyncOptions } from './compileAsync.js';

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -52,6 +52,13 @@ export interface Connector extends BaseProps {
     start?: Arrowhead | null;
     end?: Arrowhead | null;
   };
+  /** Pre-computed routed waypoints from an external layout engine
+   *  (ELK in Phase 2). When present — at least two points — the emit
+   *  layer uses these scene coordinates verbatim and skips port
+   *  selection, boundary math, and the built-in elbow kink logic.
+   *  Populated by `applyLayoutToScene`; LLM callers should leave it
+   *  unset and let the layout pipeline own edge geometry. */
+  routedPath?: readonly Point[];
 }
 
 export interface Sticky extends BaseProps {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -27,7 +27,12 @@ export interface LabelBox extends BaseProps {
   kind: 'labelBox';
   text?: string;
   shape: 'rectangle' | 'ellipse' | 'diamond';
-  at: Point;
+  /** Center-point scene coordinate. Optional since Phase 2: when
+   *  omitted, the layout engine places the box (provided
+   *  `DRAWCAST_LAYOUT_ENGINE` is on). If the engine is off and no `at`
+   *  is supplied, the emit layer falls back to the scene origin so
+   *  the primitive still compiles to a valid Excalidraw element. */
+  at?: Point;
   fit?: 'auto' | 'fixed';
   size?: readonly [width: number, height: number];
   rounded?: boolean;

--- a/packages/core/test/compileAsync.test.ts
+++ b/packages/core/test/compileAsync.test.ts
@@ -1,0 +1,154 @@
+// compileAsync end-to-end: feeds a scene whose coordinates are
+// deliberately absurd (every labelBox at (999, 999)) through the
+// auto-layout pipeline and verifies the emitted Excalidraw elements
+// reflect ELK's positions, not the input noise.
+
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/compile/index.js';
+import { compileAsync } from '../src/layout/compileAsync.js';
+import { sketchyTheme } from '../src/theme.js';
+import type {
+  Connector,
+  Frame,
+  LabelBox,
+  Primitive,
+  PrimitiveId,
+  Scene,
+} from '../src/primitives.js';
+import type { ExcalidrawRectangleElement } from '../src/types/excalidraw.js';
+
+function makeScene(primitives: Primitive[]): Scene {
+  return {
+    primitives: new Map(primitives.map((p) => [p.id, p])),
+    theme: sketchyTheme,
+  };
+}
+
+function box(id: string, at: readonly [number, number] = [999, 999]): LabelBox {
+  return {
+    kind: 'labelBox',
+    id: id as PrimitiveId,
+    shape: 'rectangle',
+    at,
+    fit: 'fixed',
+    size: [120, 60],
+    text: id.toUpperCase(),
+  };
+}
+
+function edge(id: string, from: string, to: string): Connector {
+  return {
+    kind: 'connector',
+    id: id as PrimitiveId,
+    from: from as PrimitiveId,
+    to: to as PrimitiveId,
+  };
+}
+
+describe('compileAsync', () => {
+  it('falls back to compile() when useLayout is false', async () => {
+    const scene = makeScene([box('a'), box('b'), edge('c', 'a', 'b')]);
+    const sync = compile(scene);
+    const async = await compileAsync(scene, { useLayout: false });
+    expect(async.elements.length).toBe(sync.elements.length);
+    // The sync path honours the input coordinates verbatim.
+    const syncRect = sync.elements.find(
+      (el): el is ExcalidrawRectangleElement => el.type === 'rectangle',
+    );
+    const asyncRect = async.elements.find(
+      (el): el is ExcalidrawRectangleElement => el.type === 'rectangle',
+    );
+    expect(asyncRect?.x).toBe(syncRect?.x);
+  });
+
+  it('relocates labelBoxes when useLayout=true, independent of input at', async () => {
+    // Input puts both boxes on top of each other at (999, 999) — a
+    // configuration the legacy compile would render with full overlap.
+    const scene = makeScene([box('a'), box('b'), edge('c', 'a', 'b')]);
+    const result = await compileAsync(scene, { useLayout: true });
+    const rects = result.elements.filter(
+      (el): el is ExcalidrawRectangleElement => el.type === 'rectangle',
+    );
+    expect(rects).toHaveLength(2);
+    // ELK's layered algorithm starts near the origin; both boxes should
+    // land far from the poisoned input coordinate.
+    const [first, second] = rects;
+    expect(Math.abs(first!.x - 999)).toBeGreaterThan(100);
+    expect(Math.abs(second!.x - 999)).toBeGreaterThan(100);
+    // And they should no longer overlap (ELK spacing.nodeNode=60).
+    const overlap =
+      first!.x < second!.x + second!.width &&
+      first!.x + first!.width > second!.x &&
+      first!.y < second!.y + second!.height &&
+      first!.y + first!.height > second!.y;
+    expect(overlap).toBe(false);
+  });
+
+  it('is deterministic when called twice with the same scene', async () => {
+    const scene = makeScene([
+      box('a', [0, 0]),
+      box('b', [0, 0]),
+      box('c', [0, 0]),
+      edge('e1', 'a', 'b'),
+      edge('e2', 'b', 'c'),
+    ]);
+    const [first, second] = await Promise.all([
+      compileAsync(scene, { useLayout: true }),
+      compileAsync(scene, { useLayout: true }),
+    ]);
+    const firstRects = first.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((r) => ({ id: r.id, x: r.x, y: r.y }));
+    const secondRects = second.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((r) => ({ id: r.id, x: r.x, y: r.y }));
+    // Element ids are random per compile; compare sets of (x, y).
+    const firstCoords = firstRects.map((r) => `${r.x},${r.y}`).sort();
+    const secondCoords = secondRects.map((r) => `${r.x},${r.y}`).sort();
+    expect(firstCoords).toEqual(secondCoords);
+  });
+
+  it('skips layout when the scene contains a frame (Phase 2 scope)', async () => {
+    const frame: Frame = {
+      kind: 'frame',
+      id: 'f' as PrimitiveId,
+      at: [10, 10],
+      size: [500, 300],
+      children: ['a' as PrimitiveId, 'b' as PrimitiveId],
+    };
+    const scene = makeScene([
+      frame,
+      box('a', [20, 20]),
+      box('b', [200, 20]),
+      edge('c', 'a', 'b'),
+    ]);
+    const sync = compile(scene);
+    const async = await compileAsync(scene, { useLayout: true });
+    // Frame triggers the skip path, so element coordinates must match
+    // the synchronous emit exactly.
+    const syncXs = sync.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((el) => el.x)
+      .sort();
+    const asyncXs = async.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((el) => el.x)
+      .sort();
+    expect(asyncXs).toEqual(syncXs);
+  });
+
+  it('falls back to compile() for a scene with no labelBoxes', async () => {
+    // Only a stray connector, no nodes: graph has zero children and we
+    // must preserve the caller's primitives untouched.
+    const lone = {
+      kind: 'connector' as const,
+      id: 'c' as PrimitiveId,
+      from: [0, 0] as readonly [number, number],
+      to: [100, 100] as readonly [number, number],
+    };
+    const scene = makeScene([lone]);
+    const sync = compile(scene);
+    const async = await compileAsync(scene, { useLayout: true });
+    expect(async.elements.length).toBe(sync.elements.length);
+  });
+});

--- a/packages/core/test/elkEngine.test.ts
+++ b/packages/core/test/elkEngine.test.ts
@@ -1,0 +1,115 @@
+// Smoke tests for the real elkjs binding. Hitting the actual ELK
+// instance — not a mock — gives us three things at once:
+//   (1) proves the bundled entry loads in the Node test runtime,
+//   (2) pins the ELK-in / ELK-out coordinate contract we feed
+//       `applyLayoutToScene` in a later commit,
+//   (3) guards determinism (randomSeed=1) from algorithm upgrades.
+
+import { describe, expect, it } from 'vitest';
+import { ElkLayoutEngine } from '../src/layout/elkEngine.js';
+import type { GraphModel } from '../src/layout/graph.js';
+
+function lineGraph(): GraphModel {
+  return {
+    id: 'scene',
+    diagramType: 'flowchart',
+    children: [
+      { id: 'a', primitiveIds: ['box-a'], width: 120, height: 60 },
+      { id: 'b', primitiveIds: ['box-b'], width: 120, height: 60 },
+      { id: 'c', primitiveIds: ['box-c'], width: 120, height: 60 },
+    ],
+    edges: [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'c' },
+    ],
+  };
+}
+
+describe('ElkLayoutEngine', () => {
+  it('assigns x/y to every node and preserves primitiveIds round-trip', async () => {
+    const engine = new ElkLayoutEngine();
+    const result = await engine.layout(lineGraph());
+
+    expect(result.children).toHaveLength(3);
+    for (const node of result.children) {
+      expect(Number.isFinite(node.x)).toBe(true);
+      expect(Number.isFinite(node.y)).toBe(true);
+      expect(node.width).toBeGreaterThan(0);
+      expect(node.height).toBeGreaterThan(0);
+      expect(node.primitiveIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('layered + DOWN flowchart lays out a 3-node chain top-to-bottom', async () => {
+    const engine = new ElkLayoutEngine();
+    const result = await engine.layout(lineGraph());
+    const byId = new Map(result.children.map((node) => [node.id, node]));
+    const a = byId.get('a')!;
+    const b = byId.get('b')!;
+    const c = byId.get('c')!;
+    // With `elk.direction: DOWN` each successor sits below its predecessor.
+    expect(a.y).toBeLessThan(b.y);
+    expect(b.y).toBeLessThan(c.y);
+  });
+
+  it('emits orthogonal edge sections with start/end points', async () => {
+    const engine = new ElkLayoutEngine();
+    const result = await engine.layout(lineGraph());
+    const edge = result.edges.find((candidate) => candidate.id === 'e1');
+    expect(edge).toBeDefined();
+    expect(edge!.sections).toBeDefined();
+    const section = edge!.sections![0]!;
+    expect(section.startPoint).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+    });
+    expect(section.endPoint).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+    });
+  });
+
+  it('is deterministic given a fixed input (randomSeed pinned)', async () => {
+    const engine = new ElkLayoutEngine();
+    const [first, second] = await Promise.all([
+      engine.layout(lineGraph()),
+      engine.layout(lineGraph()),
+    ]);
+    for (const id of ['a', 'b', 'c']) {
+      const firstNode = first.children.find((node) => node.id === id)!;
+      const secondNode = second.children.find((node) => node.id === id)!;
+      expect(firstNode.x).toBe(secondNode.x);
+      expect(firstNode.y).toBe(secondNode.y);
+    }
+  });
+
+  it('accepts fixedPosition input without failing layout', async () => {
+    // Layered algorithm recomputes positions globally and only treats
+    // `elk.position` as a soft hint, so we don't yet guarantee the
+    // laid-out node matches the requested coords. The hard-fixed path
+    // is planned for Phase 3 via the `fixed` / interactive algorithm.
+    // For now just check the engine doesn't crash and still returns
+    // finite coordinates for the pinned node.
+    const engine = new ElkLayoutEngine();
+    const graph: GraphModel = {
+      id: 'scene',
+      diagramType: 'flowchart',
+      children: [
+        {
+          id: 'pinned',
+          primitiveIds: ['p'],
+          width: 100,
+          height: 40,
+          fixedPosition: { x: 500, y: 200 },
+        },
+        { id: 'free', primitiveIds: ['f'], width: 100, height: 40 },
+      ],
+      edges: [{ id: 'e', source: 'pinned', target: 'free' }],
+    };
+    const result = await engine.layout(graph);
+    const pinned = result.children.find((node) => node.id === 'pinned')!;
+    expect(Number.isFinite(pinned.x)).toBe(true);
+    expect(Number.isFinite(pinned.y)).toBe(true);
+    expect(pinned.primitiveIds).toEqual(['p']);
+  });
+});

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -161,6 +161,209 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     expect(arrow.endBinding?.elementId).toBe(rects[1]!.id);
   });
 
+  it('elbow + horizontal pair: axis-aligned pair collapses to a straight 2-point line', () => {
+    // A and B centres on the same y → elbow would otherwise emit a
+    // degenerate kink on top of itself. Cardinal-port selection picks
+    // E/W and the degenerate-axis guard returns a 2-point polyline.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'elbow',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    expect(arrow.x).toBe(140);
+    expect(arrow.y).toBe(100);
+    expect(arrow.points).toHaveLength(2);
+    const last = arrow.points[1]!;
+    expect(arrow.x + last[0]).toBe(260);
+    expect(arrow.y + last[1]).toBe(100);
+  });
+
+  it('elbow + vertical pair: leaves the S port and arrives at N, collapses to straight', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 300],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'elbow',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    // A bottom-edge mid (100, 120) → B top-edge mid (100, 280).
+    expect(arrow.x).toBe(100);
+    expect(arrow.y).toBe(120);
+    expect(arrow.points).toHaveLength(2);
+    const last = arrow.points[1]!;
+    expect(arrow.x + last[0]).toBe(100);
+    expect(arrow.y + last[1]).toBe(280);
+  });
+
+  it('elbow + diagonal pair: horizontal-major leaves E, kinks at midX, enters W', () => {
+    // Regression for the "arrow overshoots out of the top edge" bug. When
+    // the source sits lower-left of the target, the previous logic anchored
+    // near the top-right corner of A and then kinked upward, producing the
+    // Z-with-detour seen in the user's flowchart. Cardinal ports plus
+    // horizontal-first routing yield a clean Z: E → midX → up → W.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 300],
+      fit: 'fixed',
+      size: [160, 60],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [500, 100],
+      fit: 'fixed',
+      size: [160, 60],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'elbow',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    // A right-edge mid (180, 300); B left-edge mid (420, 100).
+    expect(arrow.x).toBe(180);
+    expect(arrow.y).toBe(300);
+    expect(arrow.points).toHaveLength(4);
+
+    const toScene = (p: readonly [number, number]) =>
+      [arrow.x + p[0], arrow.y + p[1]] as const;
+    expect(toScene(arrow.points[0]!)).toEqual([180, 300]);
+    expect(toScene(arrow.points[1]!)).toEqual([300, 300]); // midX, stay on start.y
+    expect(toScene(arrow.points[2]!)).toEqual([300, 100]); // midX, rise to end.y
+    expect(toScene(arrow.points[3]!)).toEqual([420, 100]);
+  });
+
+  it('elbow + vertical-major diagonal: leaves S, kinks at midY, enters N', () => {
+    // Tall pair: |dy| > |dx| → vertical-first routing. Validates that we
+    // do not blindly fall into midX kinking for every elbow.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [200, 500],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'elbow',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+
+    // A bottom-edge mid (100, 120); B top-edge mid (200, 480).
+    expect(arrow.x).toBe(100);
+    expect(arrow.y).toBe(120);
+    expect(arrow.points).toHaveLength(4);
+
+    const toScene = (p: readonly [number, number]) =>
+      [arrow.x + p[0], arrow.y + p[1]] as const;
+    expect(toScene(arrow.points[0]!)).toEqual([100, 120]);
+    expect(toScene(arrow.points[1]!)).toEqual([100, 300]); // start.x, midY
+    expect(toScene(arrow.points[2]!)).toEqual([200, 300]); // end.x, midY
+    expect(toScene(arrow.points[3]!)).toEqual([200, 480]);
+  });
+
+  it('elbow with a raw Point endpoint falls back to the legacy boundary math', () => {
+    // Cardinal-port routing needs both ends bound to a record. When one
+    // side is a free Point the connector keeps the boundary-based anchor
+    // and the |dx| vs |dy| axis fallback so it still produces a sensible
+    // L-bend.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: [400, 400],
+      routing: 'elbow',
+    };
+    const result = compile(makeScene([a, c]));
+    const arrow = findArrow(result.elements);
+
+    // boundaryPoint picks the box exit on the A→(400,400) vector; we only
+    // pin that the arrow has 4 elbow points and ends at the raw target.
+    expect(arrow.points.length).toBeGreaterThanOrEqual(2);
+    const last = arrow.points[arrow.points.length - 1]!;
+    expect(arrow.x + last[0]).toBe(400);
+    expect(arrow.y + last[1]).toBe(400);
+    expect(arrow.startBinding).not.toBeNull();
+    expect(arrow.endBinding).toBeNull();
+  });
+
   it('raw Point endpoints are passed through unchanged (no boundary math)', () => {
     const c: Connector = {
       kind: 'connector',

--- a/packages/core/test/emit-labelBox.test.ts
+++ b/packages/core/test/emit-labelBox.test.ts
@@ -31,6 +31,31 @@ function makeScene(primitives: LabelBox[]): Scene {
   };
 }
 
+describe('emitLabelBox — optional `at` (Phase 2 hybrid contract)', () => {
+  it('renders at scene origin when `at` is omitted and the sync compile is used', () => {
+    // Sync compile path with no layout engine: missing `at` must not
+    // crash and must not emit NaN coordinates. Origin fallback is the
+    // explicit signal the caller skipped the layout pass.
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'orphan' as PrimitiveId,
+      shape: 'rectangle',
+      text: 'hi',
+    };
+    const result = compile(makeScene([box]));
+    const rect = result.elements.find(
+      (el): el is ExcalidrawRectangleElement => el.type === 'rectangle',
+    );
+    expect(rect).toBeDefined();
+    expect(Number.isFinite(rect!.x)).toBe(true);
+    expect(Number.isFinite(rect!.y)).toBe(true);
+    // Shape centre sits on (0, 0) so the rectangle itself lives at
+    // half-size offsets from the origin.
+    expect(rect!.x + rect!.width / 2).toBe(0);
+    expect(rect!.y + rect!.height / 2).toBe(0);
+  });
+});
+
 describe('emitLabelBox — container-bound text geometry (B1)', () => {
   it('text element sits inside the container bbox with baseline set', () => {
     const p: LabelBox = {

--- a/packages/mcp-server/src/tools/drawExport.ts
+++ b/packages/mcp-server/src/tools/drawExport.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import {
-  compile,
+  compileAsync,
   serializeAsClipboardJSON,
   serializeAsExcalidrawFile,
   serializeAsObsidianMarkdown,
@@ -91,7 +91,9 @@ export const drawExport = defineTool({
     }
 
     const scene: Scene = sceneSnapshot;
-    const result = compile(scene);
+    // Phase 2: MCP export runs the auto-layout pipeline by default.
+    // Callers can force the legacy sync path via `DRAWCAST_LAYOUT_ENGINE=off`.
+    const result = await compileAsync(scene);
 
     // Warning summary — prepend a single line when we have any so the model
     // can surface them without inflating the output.

--- a/packages/mcp-server/src/tools/drawUpsertBox.ts
+++ b/packages/mcp-server/src/tools/drawUpsertBox.ts
@@ -38,7 +38,10 @@ export const drawUpsertBoxInputSchema = z.object({
   id: z.string().min(1),
   text: z.string().optional(),
   shape: ShapeSchema.optional(),
-  at: PointSchema,
+  // `at` is optional since Phase 2: omit it and the layout engine picks
+  // a position. Kept compatible with prior callers that still pass
+  // explicit coordinates — those are treated as a positional hint.
+  at: PointSchema.optional(),
   style: StyleRefSchema.optional(),
   fit: FitSchema.optional(),
   size: SizeSchema.optional(),
@@ -56,7 +59,7 @@ export const drawUpsertBoxInputSchema = z.object({
 export type DrawUpsertBoxInput = z.infer<typeof drawUpsertBoxInputSchema>;
 
 const DESCRIPTION =
-  'Add or update a labeled box in the current scene. Use this for nodes in a diagram (process, decision, data, etc.). Same id re-applies as an update (upsert). Size auto-fits to text unless fit="fixed" with explicit size. Pass `returnPreview: true` to receive a PNG snapshot of the scene after the upsert for visual self-review.';
+  'Add or update a labeled box in the current scene. Use this for nodes in a diagram (process, decision, data, etc.). Same id re-applies as an update (upsert). Size auto-fits to text unless fit="fixed" with explicit size. Omit `at` to let the layout engine pick a position — only pass explicit coordinates when the user specifically asked to pin or place the box. Pass `returnPreview: true` to receive a PNG snapshot of the scene after the upsert for visual self-review.';
 
 export const drawUpsertBox = defineTool({
   name: 'draw_upsert_box',
@@ -74,7 +77,8 @@ export const drawUpsertBox = defineTool({
       },
       at: {
         ...POINT_JSON_SCHEMA,
-        description: 'Scene coordinate [x, y]',
+        description:
+          'Scene coordinate [x, y]. Optional — omit to let the layout engine place the box. Provide only when the user explicitly asked to pin a position.',
       },
       style: STYLE_REF_JSON_SCHEMA,
       fit: {
@@ -106,7 +110,7 @@ export const drawUpsertBox = defineTool({
       opacity: { type: 'number', description: '0–100' },
       returnPreview: RETURN_PREVIEW_JSON_SCHEMA,
     },
-    required: ['id', 'at'],
+    required: ['id'],
   },
   async execute(rawArgs, store, deps): Promise<ToolExecutionResult> {
     const parsed = drawUpsertBoxInputSchema.safeParse(rawArgs);
@@ -139,7 +143,7 @@ export const drawUpsertBox = defineTool({
       kind: 'labelBox',
       id: args.id as PrimitiveId,
       shape: args.shape ?? 'rectangle',
-      at: [args.at[0], args.at[1]],
+      ...(args.at !== undefined && { at: [args.at[0], args.at[1]] as const }),
       ...(args.text !== undefined && { text: sanitizeLabelText(args.text) }),
       ...(args.style !== undefined && { style: normalizeStyleRef(args.style) }),
       ...(args.fit !== undefined && { fit: args.fit }),

--- a/packages/mcp-server/test/tools.box.test.ts
+++ b/packages/mcp-server/test/tools.box.test.ts
@@ -69,17 +69,17 @@ describe('draw_upsert_box', () => {
     expect(stored.shape).toBe('diamond');
   });
 
-  it('returns isError when required `at` is missing', async () => {
+  it('accepts an upsert without `at` and defers placement to the layout engine', async () => {
+    // Phase 2 contract: `at` is optional. The stored primitive reflects
+    // the caller's intent to leave placement open — no default coords
+    // are synthesised at MCP level. The core emit layer / compileAsync
+    // decide what to do from there.
     const store = new SceneStore();
-    const result = await drawUpsertBox.execute(
-      // Cast to bypass the compile-time check — this simulates an
-      // ill-formed request coming over the wire.
-      { id: 'a' } as never,
-      store,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toMatch(/at:/i);
-    expect(store.getAllPrimitives()).toHaveLength(0);
+    const result = await drawUpsertBox.execute({ id: 'a', text: 'A' }, store);
+    expect(result.isError).toBeUndefined();
+    expect(store.getAllPrimitives()).toHaveLength(1);
+    const stored = store.getPrimitive(asId('a')) as LabelBox;
+    expect(stored.at).toBeUndefined();
   });
 
   it('returns isError when fit="fixed" but size is omitted', async () => {

--- a/packages/mcp-server/test/tools.integration.test.ts
+++ b/packages/mcp-server/test/tools.integration.test.ts
@@ -79,9 +79,12 @@ describe('core tools registration', () => {
 
   it('tools/call surfaces zod validation failures as isError', async () => {
     const { client } = await connectPair();
+    // `at` is optional since Phase 2 so "id only" is a valid payload.
+    // Use opacity > 100 which zod rejects to trigger the validation
+    // failure path.
     const result = await client.callTool({
       name: 'draw_upsert_box',
-      arguments: { id: 'bad' },
+      arguments: { id: 'bad', opacity: 200 },
     });
     expect(result.isError).toBe(true);
     await client.close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
 
   packages/core:
     dependencies:
+      elkjs:
+        specifier: ^0.11.1
+        version: 0.11.1
       lodash-es:
         specifier: ^4.17.21
         version: 4.18.1
@@ -2277,6 +2280,9 @@ packages:
 
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -5801,6 +5807,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.340: {}
+
+  elkjs@0.11.1: {}
 
   encodeurl@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   evals:
     dependencies:
+      '@drawcast/core':
+        specifier: workspace:*
+        version: link:../packages/core
       '@excalidraw/excalidraw':
         specifier: 0.17.6
         version: 0.17.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary

drawcast Phase 1 (elbow hotfix) + Phase 2 (ELK auto-layout) 가 한 PR에 모두 담긴 **단일 PR 전환**. 토론 결과에 따라 커밋 경계를 엄격히 쪼개서 bisect 가능성을 유지하고, 개선 효과를 이미지로 검증했음.

### 토론 이력 요약

- `/socratic-debate` 로 advocate / skeptic 3라운드 공방. 초기 제안(단일 PR 전부)은 `eval baseline` 이 하나뿐이라 실패 원인 bisect 불가 → catastrophic 판정. 수렴한 최종 경로 **C**:
  - 단일 PR 유지 + 7개 엄격 커밋 경계
  - `render.ts` 뷰포트 역신호를 **첫 커밋**으로 선결
  - Tauri WebView 는 compileAsync 경로에서 제외 (Node 전용)
  - `DRAWCAST_LAYOUT_ENGINE=off` escape hatch 로 즉시 롤백 가능

## Commit-by-commit (order matters)

| # | Commit | 변경 |
|---|--------|------|
| pre | `f74e5b1` | fix(core): port-aware elbow routing — Phase 1 증상 제거 |
| pre | `e175dfc` | docs: draft Phase 2 layout engine design |
| 1 | `fe76770` | fix(evals): dynamic render scale + strict pass gate — 역신호 경로 차단 |
| 2 | `cb57e48` | feat(core): graph model + layout engine interfaces |
| 3 | `f3011a2` | feat(core): ELK layout engine binding (Node-only, guarded) |
| 4 | `cdfe156` | feat(core): compileAsync pipeline behind flag (default off) |
| 5 | `6a500ab` | feat(mcp): at-optional labelBox upserts |
| 6 | `3262d86` | feat(app): system-prompt v2 |
| 7 | `2adaa4a` | feat(core,mcp): flag default on + draw_export through compileAsync |
| post | `f08e7ec` | chore(evals): layout before/after smoke renderer |

각 커밋은 독립적으로 CI green + `DRAWCAST_LAYOUT_ENGINE=off` 복귀 가능. 실패 시 `git revert <sha>` 단위.

## E2E 검증 (이미지 베이스)

`evals/runner/scripts/layout-smoke.ts` 로 동일 flowchart를 `useLayout=false` vs `useLayout=true` 로 렌더. 로그인 플로우 10-노드, 11-엣지, 한글 레이블.

- **BEFORE** (layout off, `at` 없는 선언형 입력): 모든 노드가 (0,0)에 겹쳐 단일 덩어리 — 읽기 불가.
- **AFTER** (layout on): ELK `layered` 알고리즘이 top-down flowchart로 펼침. 시작 → 이메일 입력 → 검증? → 유효/무효 분기 → 인증 → 성공/실패 → 대시보드 → 종료 흐름이 시각적으로 따라감.

재현:
```
pnpm install
pnpm -C packages/core build
pnpm -C evals exec tsc -p tsconfig.json
node evals/dist/runner/scripts/layout-smoke.js /tmp/layout-smoke
```

## 안전장치

- **Tauri 격리**: `app/src/**` 의 `compile()` 호출 6곳 모두 sync path 유지. `compileAsync` 는 MCP server 만 사용.
- **env escape hatch**: `DRAWCAST_LAYOUT_ENGINE=off` 로 런타임 롤백, 코드 revert 불필요.
- **역신호 선결**: Commit #1 이 ELK 전에 들어가 뷰포트 scale 축소 → `readability <=1` → `anyLow fail` 경로를 차단. ELK 개선이 rubric 점수 상승으로 반영되도록.
- **Node-only 3가드**: elkEngine.ts 파일 주석 + docs/11-layout-engine.md §9.5 + compileAsync env guard.

## Test plan

- [x] `pnpm -C packages/core typecheck` ✅
- [x] `pnpm -C packages/core test` — 85/85 (elbow 5 + elkEngine 5 + compileAsync 5 신규)
- [x] `pnpm -C packages/mcp-server typecheck` ✅
- [x] `pnpm -C packages/mcp-server test` — 131/131 (tools.box + tools.integration 갱신)
- [x] `pnpm -C packages/app typecheck` ✅
- [x] `pnpm -C evals typecheck` ✅
- [x] `node evals/dist/runner/scripts/layout-smoke.js` — before/after PNG 생성, 시각 확인 완료

## Follow-ups (별도 이슈)

- docs/11-layout-engine.md §10 의 Q1~Q14 합의 (특히 Q6 `semanticKind` 네이밍, Q4 아이콘 세트, Q12 아이콘 embed vs overlay)
- Phase 3: Frame nested compound graph, architecture 다이어그램 프리셋, 아이콘 레지스트리
- Phase 3: Tauri WebView 측 layout 반영 (현재는 sync path라 LLM이 `at` 생략한 노드가 UI에서 (0,0))
- Phase 4: sequence 다이어그램 전용 레이아웃 (ELK 부적합)
- ELK `fixedPosition` 을 layered에서 soft-hint 이상으로 보장하려면 Phase 3의 `interactive` / `fixed` 알고리즘

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional explicit coordinates for boxes and an opt-in automatic layout pass that can auto-position and size diagram elements; async “compile with layout” flow and a layout smoke-render script.
* **Documentation**
  * Added comprehensive Layout Engine design doc and updated system prompt guidance to discourage manual coordinate computation.
* **Tests**
  * Added extensive tests for layout engine, async compile, label placement, and improved elbow connector anchoring.
* **Chores**
  * Rendering/export tweaks and new evaluation metrics for overlap/strict pass reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->