### PR TITLE
fix(core): measure labelBox size before ELK layout (#36)

### DIFF
--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -10,8 +10,27 @@
 // out of their container, so `buildGraphModel` reports null and the
 // caller falls back to the synchronous compile path.
 
-import type { Primitive, Scene } from '../primitives.js';
+import { measureText } from '../measure.js';
+import type { LabelBox, Primitive, Scene } from '../primitives.js';
+import type { Theme } from '../theme.js';
 import type { GraphEdge, GraphModel, GraphNode } from './graph.js';
+
+// Kept in sync with emit/labelBox.ts (DEFAULT_PADDING, FIXED_FALLBACK_*)
+// so a node sized here survives round-trip through ELK and the emit
+// layer without growing or shrinking. A mismatch would show up as the
+// emit path re-fitting the shape to a different size than ELK reserved.
+const LAYOUT_PADDING = 20;
+const MIN_LAYOUT_WIDTH = 80;
+const MIN_LAYOUT_HEIGHT = 40;
+const FIXED_FALLBACK_WIDTH = 150;
+const FIXED_FALLBACK_HEIGHT = 60;
+// Ellipse/diamond bounding boxes must be larger than their inscribed
+// rectangle, otherwise the emit layer's `maxTextWidth = width - 2*padding`
+// clamps wrap to fewer lines than ELK reserved vertical space for and
+// the glyph run leaks past the curved/angled edges. √2 matches the
+// inscribed-rectangle-in-ellipse ratio; diamond's worst case is the
+// same under the (w, h) symmetric assumption emitLabelBox already makes.
+const NON_RECT_INFLATION = Math.SQRT2;
 
 export interface BuildGraphModelOptions {
   /** When true (default) a scene that contains any Frame is treated as
@@ -38,7 +57,7 @@ export function buildGraphModel(
 
   for (const primitive of primitives) {
     if (primitive.kind === 'labelBox') {
-      const node = labelBoxToNode(primitive);
+      const node = labelBoxToNode(primitive, scene.theme);
       nodes.push(node);
       nodeIds.add(node.id);
     }
@@ -61,31 +80,85 @@ export function buildGraphModel(
 
 function labelBoxToNode(
   primitive: Extract<Primitive, { kind: 'labelBox' }>,
+  theme: Theme,
 ): GraphNode {
+  const { width, height } = measureLabelBoxSize(primitive, theme);
   const node: GraphNode = {
     id: primitive.id,
     primitiveIds: [primitive.id],
+    width,
+    height,
   };
-  // Measured size takes priority; without it ELK falls back to engine
-  // defaults (DEFAULT_NODE_WIDTH/HEIGHT) which loosely match the
-  // labelBox auto-fit output from Phase 1.
-  if (primitive.size !== undefined) {
-    node.width = primitive.size[0];
-    node.height = primitive.size[1];
-  }
   // An explicit `at` is the LLM's (or user's) positional intent — pass
   // it to ELK as a fixed-position hint so the layer algorithm tries to
-  // respect it. `at` is centre-based; ELK expects top-left, so we need
-  // a size to translate and skip the hint otherwise. Layered treats
+  // respect it. `at` is centre-based; ELK expects top-left, so convert
+  // using the measured (not necessarily declared) size. Layered treats
   // `elk.position` as a soft hint today; Phase 3 will introduce the
   // interactive/fixed algorithm for hard pinning.
-  if (primitive.at !== undefined && primitive.size !== undefined) {
+  if (primitive.at !== undefined) {
     node.fixedPosition = {
-      x: primitive.at[0] - primitive.size[0] / 2,
-      y: primitive.at[1] - primitive.size[1] / 2,
+      x: primitive.at[0] - width / 2,
+      y: primitive.at[1] - height / 2,
     };
   }
   return node;
+}
+
+/**
+ * Pick a bounding box for a LabelBox before it enters the layout engine.
+ *
+ * Without this the ELK engine falls back to its generic 160×60 default
+ * (see elkEngine.ts DEFAULT_NODE_WIDTH/HEIGHT), which is too small for
+ * multi-line Korean labels like "이메일 / 비밀번호 입력" — ELK reserves
+ * a box that the emit-layer text node then overflows (#36).
+ *
+ * The goal is size parity with `emitLabelBox`'s own auto-fit output so
+ * a node sized here stays that size after `applyLayoutToScene` pins it
+ * via `fit:'fixed'` and the emit layer reads it back.
+ */
+function measureLabelBoxSize(
+  primitive: LabelBox,
+  theme: Theme,
+): { width: number; height: number } {
+  // fit:'fixed' pins the declared size through emit. Mirror the emit
+  // fallback when size is missing rather than measure (users who opt
+  // into fixed are signalling "don't auto-fit").
+  if (primitive.fit === 'fixed') {
+    if (primitive.size !== undefined) {
+      return { width: primitive.size[0], height: primitive.size[1] };
+    }
+    return { width: FIXED_FALLBACK_WIDTH, height: FIXED_FALLBACK_HEIGHT };
+  }
+
+  // Auto (default). An explicit size wins over measurement so caller
+  // overrides aren't silently discarded.
+  if (primitive.size !== undefined) {
+    return { width: primitive.size[0], height: primitive.size[1] };
+  }
+
+  // No size: measure the raw text and pad, matching emitLabelBox's
+  // own auto-fit rule. Wrapping isn't applied here — we don't yet
+  // know a target max width, so we reserve the whole unwrapped run.
+  const fontSize = primitive.fontSize ?? theme.defaultFontSize;
+  const fontFamily = primitive.fontFamily ?? theme.defaultFontFamily;
+
+  let width = MIN_LAYOUT_WIDTH;
+  let height = MIN_LAYOUT_HEIGHT;
+  if (primitive.text !== undefined && primitive.text !== '') {
+    const metrics = measureText({
+      text: primitive.text,
+      fontSize,
+      fontFamily,
+    });
+    width = Math.max(metrics.width + LAYOUT_PADDING * 2, MIN_LAYOUT_WIDTH);
+    height = Math.max(metrics.height + LAYOUT_PADDING * 2, MIN_LAYOUT_HEIGHT);
+  }
+
+  if (primitive.shape !== 'rectangle') {
+    width = Math.ceil(width * NON_RECT_INFLATION);
+    height = Math.ceil(height * NON_RECT_INFLATION);
+  }
+  return { width, height };
 }
 
 function connectorToEdge(

--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -188,6 +188,7 @@ function hydrateNode(
   // unlaid `GraphNode[]`, which `exactOptionalPropertyTypes` refuses
   // to widen into `LaidOutNode[]` even though the overwrite below
   // would replace the value entirely.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { children: _unlaidChildren, ...rest } = original;
   const laidOut: LaidOutNode = {
     ...rest,

--- a/packages/core/test/buildGraphModel.test.ts
+++ b/packages/core/test/buildGraphModel.test.ts
@@ -1,0 +1,142 @@
+// Size measurement for labelBox -> GraphNode. Regression coverage for
+// #36: when an LLM emits a labelBox with text but no explicit size, the
+// layout layer must reserve enough room for the emitted glyph run so the
+// emit path's container-bound text never overflows.
+
+import { describe, expect, it } from 'vitest';
+import { buildGraphModel } from '../src/layout/buildGraphModel.js';
+import { measureText } from '../src/measure.js';
+import { sketchyTheme } from '../src/theme.js';
+import type {
+  LabelBox,
+  Primitive,
+  PrimitiveId,
+  Scene,
+} from '../src/primitives.js';
+
+const PADDING = 20;
+const MIN_W = 80;
+const MIN_H = 40;
+
+function makeScene(primitives: Primitive[]): Scene {
+  return {
+    primitives: new Map(primitives.map((p) => [p.id, p])),
+    theme: sketchyTheme,
+  };
+}
+
+function node(id: string, graph: ReturnType<typeof buildGraphModel>) {
+  if (graph === null) throw new Error('expected non-null GraphModel');
+  const found = graph.children.find((n) => n.id === id);
+  if (found === undefined) throw new Error(`node ${id} missing from graph`);
+  return found;
+}
+
+describe('buildGraphModel — labelBox size measurement', () => {
+  it('measures text and pads when size is omitted (rectangle)', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'r' as PrimitiveId,
+      shape: 'rectangle',
+      text: '이메일 / 비밀번호 입력',
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('r', graph);
+
+    const metrics = measureText({
+      text: box.text!,
+      fontSize: sketchyTheme.defaultFontSize,
+      fontFamily: sketchyTheme.defaultFontFamily,
+    });
+    expect(n.width).toBe(Math.max(metrics.width + PADDING * 2, MIN_W));
+    expect(n.height).toBe(Math.max(metrics.height + PADDING * 2, MIN_H));
+  });
+
+  it('inflates ellipse / diamond so the inscribed rectangle fits text + padding', () => {
+    const ellipse: LabelBox = {
+      kind: 'labelBox',
+      id: 'e' as PrimitiveId,
+      shape: 'ellipse',
+      text: '시작',
+    };
+    const diamond: LabelBox = {
+      kind: 'labelBox',
+      id: 'd' as PrimitiveId,
+      shape: 'diamond',
+      text: '입력값 검증',
+    };
+    const graph = buildGraphModel(makeScene([ellipse, diamond]));
+
+    for (const shape of ['e', 'd'] as const) {
+      const n = node(shape, graph);
+      const metrics = measureText({
+        text: shape === 'e' ? ellipse.text! : diamond.text!,
+        fontSize: sketchyTheme.defaultFontSize,
+        fontFamily: sketchyTheme.defaultFontFamily,
+      });
+      const rectW = Math.max(metrics.width + PADDING * 2, MIN_W);
+      const rectH = Math.max(metrics.height + PADDING * 2, MIN_H);
+      // Must at least leave room for the inscribed rectangle; √2 is the
+      // tightest safe ratio.
+      expect(n.width).toBeGreaterThanOrEqual(Math.ceil(rectW * Math.SQRT2));
+      expect(n.height).toBeGreaterThanOrEqual(Math.ceil(rectH * Math.SQRT2));
+    }
+  });
+
+  it('falls back to min dimensions when text is empty', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'blank' as PrimitiveId,
+      shape: 'rectangle',
+      text: '',
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('blank', graph);
+    expect(n.width).toBe(MIN_W);
+    expect(n.height).toBe(MIN_H);
+  });
+
+  it('honours an explicit size without remeasuring', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'sized' as PrimitiveId,
+      shape: 'rectangle',
+      size: [200, 80],
+      text: 'x'.repeat(500), // huge text — would blow past 200 if we measured
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('sized', graph);
+    expect(n.width).toBe(200);
+    expect(n.height).toBe(80);
+  });
+
+  it('uses the fixed-fit fallback when fit:"fixed" arrives without size', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'fixedless' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      text: 'anything',
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('fixedless', graph);
+    // Mirrors emit/labelBox.ts FIXED_FALLBACK_W / FIXED_FALLBACK_H.
+    expect(n.width).toBe(150);
+    expect(n.height).toBe(60);
+  });
+
+  it('derives fixedPosition from `at` using the measured size', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'anchored' as PrimitiveId,
+      shape: 'rectangle',
+      at: [500, 300],
+      text: 'hi',
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('anchored', graph);
+    expect(n.fixedPosition).toBeDefined();
+    expect(n.fixedPosition!.x).toBe(500 - n.width! / 2);
+    expect(n.fixedPosition!.y).toBe(300 - n.height! / 2);
+  });
+});

--- a/packages/core/test/compileAsync.test.ts
+++ b/packages/core/test/compileAsync.test.ts
@@ -6,6 +6,8 @@
 import { describe, expect, it } from 'vitest';
 import { compile } from '../src/compile/index.js';
 import { compileAsync } from '../src/layout/compileAsync.js';
+import { measureText } from '../src/measure.js';
+import { wrapText } from '../src/wrap.js';
 import { sketchyTheme } from '../src/theme.js';
 import type {
   Connector,
@@ -15,7 +17,12 @@ import type {
   PrimitiveId,
   Scene,
 } from '../src/primitives.js';
-import type { ExcalidrawRectangleElement } from '../src/types/excalidraw.js';
+import type {
+  ExcalidrawDiamondElement,
+  ExcalidrawEllipseElement,
+  ExcalidrawRectangleElement,
+  ExcalidrawTextElement,
+} from '../src/types/excalidraw.js';
 
 function makeScene(primitives: Primitive[]): Scene {
   return {
@@ -136,6 +143,141 @@ describe('compileAsync', () => {
       .sort();
     expect(asyncXs).toEqual(syncXs);
   });
+
+  // --- #36 regression: labelBox text must fit inside its container -----------
+  //
+  // The emit layer sizes text using:
+  //   maxTextWidth = shape.width - 2 * padding   (padding = 20)
+  //   wrapped      = wrapText(text, maxTextWidth, fontSize, fontFamily)
+  //   wrappedMetrics = measureText(wrapped)
+  // and then *clamps* text.width/height to shape.width/height. That clamp
+  // is what made the pre-fix overflow invisible to a naive bbox check —
+  // the text element's own bbox was fine, but the glyphs rendered at
+  // wrappedMetrics dimensions, which was wider/taller than the shape.
+  //
+  // So the real invariant is: measuring the wrapped text must produce
+  // a box that fits inside the shape's content area (shape size minus
+  // the 20px padding each side). For ellipse/diamond the glyph run has
+  // to fit inside the inscribed rectangle (shape / √2) — otherwise the
+  // corners/edges of the curve clip the text.
+  type LabelBoxCase = {
+    name: string;
+    text: string;
+    shape: LabelBox['shape'];
+  };
+
+  const OVERFLOW_CASES: readonly LabelBoxCase[] = [
+    // The exact labels from #36's screenshot — Korean multi-line was the
+    // reproducer that ELK's 160×60 default couldn't hold.
+    { name: 'korean-rect-wide', text: '이메일 / 비밀번호 입력', shape: 'rectangle' },
+    { name: 'korean-diamond', text: '입력값 검증', shape: 'diamond' },
+    { name: 'korean-diamond-long', text: '인증 성공?', shape: 'diamond' },
+    { name: 'korean-ellipse-short', text: '시작', shape: 'ellipse' },
+    { name: 'korean-ellipse-long', text: '종료 상태 확인', shape: 'ellipse' },
+    { name: 'korean-rect-multiline', text: '오류 메시지\n표시', shape: 'rectangle' },
+    // Not Korean — guard against regressing for other scripts too.
+    { name: 'english-long', text: 'Authenticate via OAuth2', shape: 'rectangle' },
+    { name: 'english-ellipse', text: 'Start', shape: 'ellipse' },
+    { name: 'english-diamond', text: 'Valid?', shape: 'diamond' },
+  ];
+
+  const INSCRIBED_SHAPES = new Set<LabelBox['shape']>(['ellipse', 'diamond']);
+  const EMIT_PADDING = 20; // emit/labelBox.ts DEFAULT_PADDING
+
+  function findShapeFor(
+    result: { elements: readonly unknown[] },
+    primitiveId: string,
+  ): ExcalidrawRectangleElement | ExcalidrawEllipseElement | ExcalidrawDiamondElement {
+    const shape = (result.elements as Array<Record<string, unknown>>).find(
+      (el) =>
+        (el.type === 'rectangle' || el.type === 'ellipse' || el.type === 'diamond') &&
+        (el.customData as { drawcastPrimitiveId?: string } | undefined)
+          ?.drawcastPrimitiveId === primitiveId,
+    );
+    if (shape === undefined) {
+      throw new Error(`no shape emitted for primitive ${primitiveId}`);
+    }
+    return shape as
+      | ExcalidrawRectangleElement
+      | ExcalidrawEllipseElement
+      | ExcalidrawDiamondElement;
+  }
+
+  function findTextFor(
+    result: { elements: readonly unknown[] },
+    shapeId: string,
+  ): ExcalidrawTextElement {
+    const text = (result.elements as Array<Record<string, unknown>>).find(
+      (el) => el.type === 'text' && el.containerId === shapeId,
+    );
+    if (text === undefined) {
+      throw new Error(`no bound text for shape ${shapeId}`);
+    }
+    return text as ExcalidrawTextElement;
+  }
+
+  it.each(OVERFLOW_CASES)(
+    'emitted text fits inside the shape for $name ($shape)',
+    async ({ text, shape }) => {
+      // Scene deliberately omits `at` and `size` — the exact Phase 2
+      // hybrid contract that triggered #36. Two boxes + an edge so ELK
+      // has a real layout to compute, not a single-node no-op.
+      const target: LabelBox = {
+        kind: 'labelBox',
+        id: 'target' as PrimitiveId,
+        shape,
+        text,
+      };
+      const neighbour: LabelBox = {
+        kind: 'labelBox',
+        id: 'neighbour' as PrimitiveId,
+        shape: 'rectangle',
+        text: 'x',
+      };
+      const link: Connector = {
+        kind: 'connector',
+        id: 'e1' as PrimitiveId,
+        from: 'target' as PrimitiveId,
+        to: 'neighbour' as PrimitiveId,
+      };
+
+      const result = await compileAsync(makeScene([target, neighbour, link]), {
+        useLayout: true,
+      });
+
+      const shapeEl = findShapeFor(result, target.id);
+      const textEl = findTextFor(result, shapeEl.id);
+
+      // Replay the emit layer's wrap/measure contract so we see what the
+      // renderer will actually paint, not the clamped `textEl.width/height`.
+      const fontSize = sketchyTheme.defaultFontSize;
+      const fontFamily = sketchyTheme.defaultFontFamily;
+      const maxTextWidth = Math.max(shapeEl.width - EMIT_PADDING * 2, 1);
+      const wrapped = wrapText({ text, maxWidth: maxTextWidth, fontSize, fontFamily });
+      const metrics = measureText({ text: wrapped, fontSize, fontFamily });
+
+      // Sanity: emit really did bind text to this shape.
+      expect(textEl.containerId).toBe(shapeEl.id);
+
+      // Invariant 1: glyph run width/height fit inside the shape minus
+      // padding. This is what the #36 screenshot showed as "text bleeds
+      // past the rectangle / diamond corners".
+      expect(metrics.width).toBeLessThanOrEqual(shapeEl.width - EMIT_PADDING * 2);
+      expect(metrics.height).toBeLessThanOrEqual(shapeEl.height - EMIT_PADDING * 2);
+
+      // Invariant 2: ellipse/diamond need the content area inside the
+      // *inscribed rectangle*, not the bounding box. The inscribed rect
+      // of an axis-aligned ellipse/diamond with bbox (W, H) has width
+      // W/√2, height H/√2. If the shape bbox exists but its inscribed
+      // rect is smaller than the padded glyph run, corners still clip.
+      if (INSCRIBED_SHAPES.has(shape)) {
+        const inscribedW = shapeEl.width / Math.SQRT2;
+        const inscribedH = shapeEl.height / Math.SQRT2;
+        expect(metrics.width + EMIT_PADDING * 2).toBeLessThanOrEqual(inscribedW + 1);
+        expect(metrics.height + EMIT_PADDING * 2).toBeLessThanOrEqual(inscribedH + 1);
+      }
+    },
+  );
 
   it('falls back to compile() for a scene with no labelBoxes', async () => {
     // Only a stray connector, no nodes: graph has zero children and we


### PR DESCRIPTION
## Summary
- Closes #36. After PR #35 (Phase 2 ELK auto-layout), `labelBox` primitives without explicit `size` fell through to ELK's generic 160×60 default, and multi-line Korean labels like "이메일 / 비밀번호 입력" spilled past their shapes.
- `buildGraphModel` now runs `measureText` + padding for size-less labelBoxes, mirroring `emit/labelBox.ts` auto-fit output so ELK reserves the same box the emit layer then renders into.
- Ellipse / diamond bounding boxes get inflated by √2 so their inscribed rectangle still covers the text-plus-padding area — without this, `maxTextWidth = width - 2*padding` wrap clamps too tightly and glyphs leak past the curved/angled edges.
- `fit: 'fixed'` and explicit `size` both still bypass measurement so caller overrides aren't silently discarded.

## Visual before / after
Ran `evals/runner/scripts/layout-smoke.ts` against the login flowchart cited in the issue.

**Before** (main, ELK default 160×60 fallback):
- "입력값 검증" diamond, "이메일 / 비밀번호 입력" rectangle, "오류 메시지 표시" rectangle — all overflow.

**After** (this branch):
- All labels sit cleanly inside their containers; ELK spacing still respected.

## Test plan
- [x] `pnpm -C packages/core test` — 93/93 passing, including 6 new `buildGraphModel.test.ts` cases (rectangle measurement, ellipse/diamond inflation, empty text → min, explicit size/fit:fixed honoured, fixedPosition derivation).
- [x] `pnpm -r test` — full workspace green (core 93, mcp-server 131, app 66).
- [x] `pnpm -r build` — type-checks clean across packages.
- [x] `node evals/dist/runner/scripts/layout-smoke.js /tmp/x` — overflow visually gone.

## Scope notes
- Connector label positioning is a separate concern and was not touched here.
- Per-shape padding is a single `√2` factor; a more precise per-shape geometry pass (e.g. diamond's exact inscribed-rect formula) can land later if we see cases where √2 is over- or under-shooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved automatic node dimension calculations to intelligently derive sizes from text metrics when explicit dimensions are not specified, respecting fit modes
  * Enhanced positioning calculations for center-based node placement
  * Better dimension handling for non-rectangular shapes

* **Tests**
  * Added comprehensive test coverage for node dimension measurement behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->