### PR TITLE
fix(core): anchor flowchart source nodes to top layer

### DIFF
--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -54,7 +54,16 @@ const ALGORITHM_BY_TYPE: Record<DiagramType, string> = {
 
 /** Baseline layout options. Values kept as strings because ELK's JSON
  *  options dict expects strings regardless of the underlying numeric
- *  type. `elk.randomSeed` pins determinism per docs §2.4. */
+ *  type. `elk.randomSeed` pins determinism per docs §2.4.
+ *
+ *  `layering.strategy=LONGEST_PATH_SOURCE` anchors every source node
+ *  (incoming-edge count == 0, e.g. the "start" primitive in a flowchart)
+ *  to the first layer. ELK's default `NETWORK_SIMPLEX` minimises total
+ *  edge length and, in graphs with retry loops (e.g. "재시도? → 입력"),
+ *  happily demotes the source to a middle/bottom layer — which rubric
+ *  reviewers consistently flagged as an unnatural flow. This strategy
+ *  does not depend on Claude's node-definition order, so it's stable
+ *  across the non-deterministic AI output. */
 const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.algorithm': 'layered',
   'elk.direction': 'DOWN',
@@ -62,6 +71,7 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.layered.spacing.nodeNodeBetweenLayers': '60',
   'elk.edgeRouting': 'ORTHOGONAL',
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+  'elk.layered.layering.strategy': 'LONGEST_PATH_SOURCE',
   'elk.randomSeed': '1',
 };
 

--- a/packages/core/test/elkEngine.test.ts
+++ b/packages/core/test/elkEngine.test.ts
@@ -83,6 +83,41 @@ describe('ElkLayoutEngine', () => {
     }
   });
 
+  it('anchors source nodes to the top layer even when a retry loop targets an early node', async () => {
+    // Regression guard for the eval finding that "start" nodes landed at
+    // the bottom of flowcharts containing a retry loop (e.g. a "retry?"
+    // decision node edge that targets the input node). With ELK's default
+    // NETWORK_SIMPLEX layering the source could be demoted to a lower
+    // layer because that minimises total edge length; LONGEST_PATH_SOURCE
+    // pins it to layer 0.
+    const engine = new ElkLayoutEngine();
+    const graph: GraphModel = {
+      id: 'scene',
+      diagramType: 'flowchart',
+      children: [
+        { id: 'start', primitiveIds: ['start'], width: 120, height: 60 },
+        { id: 'input', primitiveIds: ['input'], width: 120, height: 60 },
+        { id: 'decide', primitiveIds: ['decide'], width: 120, height: 60 },
+        { id: 'retry', primitiveIds: ['retry'], width: 120, height: 60 },
+        { id: 'done', primitiveIds: ['done'], width: 120, height: 60 },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'input' },
+        { id: 'e2', source: 'input', target: 'decide' },
+        { id: 'e3', source: 'decide', target: 'retry' },
+        { id: 'e4', source: 'decide', target: 'done' },
+        { id: 'e5', source: 'retry', target: 'input' },
+      ],
+    };
+    const result = await engine.layout(graph);
+    const byId = new Map(result.children.map((n) => [n.id, n]));
+    const start = byId.get('start')!;
+    for (const id of ['input', 'decide', 'retry', 'done']) {
+      const other = byId.get(id)!;
+      expect(start.y).toBeLessThan(other.y);
+    }
+  });
+
   it('accepts fixedPosition input without failing layout', async () => {
     // Layered algorithm recomputes positions globally and only treats
     // `elk.position` as a soft hint, so we don't yet guarantee the


### PR DESCRIPTION
## Summary
- ELK `elk.layered.layering.strategy`를 `LONGEST_PATH_SOURCE`로 변경하여 incoming edge가 없는 노드(예: `start`)를 항상 최상단 레이어에 고정한다.
- 루프가 있는 그래프에서 기본 `NETWORK_SIMPLEX`가 total edge length 최소화를 위해 source 노드를 중간/하단으로 밀어내는 문제를 해결.
- 루프 그래프에서 source 노드의 y 좌표가 최소임을 검증하는 regression test 추가.

## 근거 (E2E 검증)
`pnpm --filter drawcast-evals eval -- --id flow-login-01 --n 1` 로 AI 실호출 E2E를 반복 수행:

- **Before (baseline, NETWORK_SIMPLEX)**: rubric major_issues에 "시작점과 입력 단계가 하단에 있어 전체 흐름 방향이 위아래로 섞여 보인다" 지적. layout=2.
- **중간 시도 (GREEDY_MODEL_ORDER)**: Claude가 매 sample마다 노드 정의 순서를 다르게 내놓아 불안정. major_issues에 "주 흐름이 좌하단→우상단" 여전히 지적.
- **After (LONGEST_PATH_SOURCE)**: "시작" 노드가 최상단, 흐름이 위→아래로 자연스럽게 전개. rubric major_issues=[]로 사라짐.

## Test plan
- [x] `pnpm --filter @drawcast/core test` — 88 passed (신규 regression test 포함)
- [x] `pnpm -r test` — 전체 테스트 그린
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01` — rubric pass, major_issues 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)