### PR TITLE
fix(core): use INTERACTIVE cycle breaking for retry-heavy flowcharts

### DIFF
--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -63,7 +63,18 @@ const ALGORITHM_BY_TYPE: Record<DiagramType, string> = {
  *  happily demotes the source to a middle/bottom layer — which rubric
  *  reviewers consistently flagged as an unnatural flow. This strategy
  *  does not depend on Claude's node-definition order, so it's stable
- *  across the non-deterministic AI output. */
+ *  across the non-deterministic AI output.
+ *
+ *  `cycleBreaking.strategy=INTERACTIVE` uses the y coordinate supplied
+ *  via `fixedPosition` (set by `buildGraphModel` from the LLM's `at`
+ *  hint) to decide which edges are "back edges". The default `GREEDY`
+ *  picks the minimum feedback arc set, which can reverse the wrong
+ *  edge in multi-retry flowcharts: e.g. in a login flow with both an
+ *  "invalid input → input" and a "failed auth → input" retry, greedy
+ *  reverses the single forward edge `input → validate` because it
+ *  breaks both cycles at once — promoting `validate` to a source and
+ *  burying `input` at the bottom. Using the y hint to detect back
+ *  edges keeps the semantically-forward edge pointing downward. */
 const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.algorithm': 'layered',
   'elk.direction': 'DOWN',
@@ -72,6 +83,7 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.edgeRouting': 'ORTHOGONAL',
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
   'elk.layered.layering.strategy': 'LONGEST_PATH_SOURCE',
+  'elk.layered.cycleBreaking.strategy': 'INTERACTIVE',
   'elk.randomSeed': '1',
 };
 

--- a/packages/core/test/elkEngine.test.ts
+++ b/packages/core/test/elkEngine.test.ts
@@ -118,6 +118,106 @@ describe('ElkLayoutEngine', () => {
     }
   });
 
+  it('keeps the forward edge pointing down when multiple retry loops converge on an early node', async () => {
+    // Regression guard for the eval finding that flowcharts with two
+    // independent retry loops (validation retry + auth-failure retry)
+    // both targeting the "input" node caused ELK's GREEDY cycle
+    // breaking to reverse the single forward edge `input → validate`
+    // (since removing it breaks both cycles with one cut). That
+    // promoted `validate` to a source layer and buried `input` at
+    // the bottom. INTERACTIVE cycle breaking uses the y hint from
+    // `fixedPosition` to classify back edges instead.
+    const engine = new ElkLayoutEngine();
+    const graph: GraphModel = {
+      id: 'scene',
+      diagramType: 'flowchart',
+      children: [
+        {
+          id: 'start',
+          primitiveIds: ['start'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 400, y: 50 },
+        },
+        {
+          id: 'input',
+          primitiveIds: ['input'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 400, y: 210 },
+        },
+        {
+          id: 'validate',
+          primitiveIds: ['validate'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 400, y: 370 },
+        },
+        {
+          id: 'invalid_msg',
+          primitiveIds: ['invalid_msg'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 150, y: 530 },
+        },
+        {
+          id: 'auth',
+          primitiveIds: ['auth'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 400, y: 530 },
+        },
+        {
+          id: 'auth_check',
+          primitiveIds: ['auth_check'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 400, y: 690 },
+        },
+        {
+          id: 'fail',
+          primitiveIds: ['fail'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 150, y: 850 },
+        },
+        {
+          id: 'success',
+          primitiveIds: ['success'],
+          width: 120,
+          height: 60,
+          fixedPosition: { x: 630, y: 850 },
+        },
+      ],
+      edges: [
+        { id: 'e1', source: 'start', target: 'input' },
+        { id: 'e2', source: 'input', target: 'validate' },
+        { id: 'e3', source: 'validate', target: 'invalid_msg' },
+        { id: 'e4', source: 'validate', target: 'auth' },
+        { id: 'e5', source: 'auth', target: 'auth_check' },
+        { id: 'e6', source: 'auth_check', target: 'success' },
+        { id: 'e7', source: 'auth_check', target: 'fail' },
+        { id: 'e8', source: 'invalid_msg', target: 'input' },
+        { id: 'e9', source: 'fail', target: 'input' },
+      ],
+    };
+    const result = await engine.layout(graph);
+    const byId = new Map(result.children.map((n) => [n.id, n]));
+    const start = byId.get('start')!;
+    const input = byId.get('input')!;
+    const validate = byId.get('validate')!;
+    // The forward chain must flow downward. INTERACTIVE cycle breaking
+    // pins `input` above `validate`; GREEDY would swap them by
+    // reversing `input → validate`.
+    expect(start.y).toBeLessThan(input.y);
+    expect(input.y).toBeLessThan(validate.y);
+    // Every other node stays below `input` too, i.e. the retry targets
+    // do not bury the loop-back target.
+    for (const id of ['invalid_msg', 'auth', 'auth_check', 'fail', 'success']) {
+      expect(input.y).toBeLessThan(byId.get(id)!.y);
+    }
+  });
+
   it('accepts fixedPosition input without failing layout', async () => {
     // Layered algorithm recomputes positions globally and only treats
     // `elk.position` as a soft hint, so we don't yet guarantee the


### PR DESCRIPTION
## Summary

- 자연어 flowchart 평가에서 발견된 레이아웃 회귀를 수정
- ELK의 기본 `GREEDY` cycleBreaking이 다중 재시도 루프가 모이는 초기 노드를 그래프 최하단으로 밀어내는 문제를 `INTERACTIVE` 전략으로 해결

## 문제

`flow-login-01` E2E에서 재시도 루프가 두 개(입력 검증 실패 → input, 인증 실패 → input) 있을 때, 단일 forward edge `input → validate`를 제거하면 두 사이클이 모두 깨지므로 `GREEDY`가 그 edge를 역방향으로 뒤집었습니다. 결과:
- `validate`가 layer 0(source)로 승격
- `input`이 layer 4(최하단)로 이동
- `start → input` 엣지가 그래프 전체를 가로지르며 가독성 파괴

## 해결

`elk.layered.cycleBreaking.strategy=INTERACTIVE`. `buildGraphModel`이 LLM의 `at` 힌트에서 `fixedPosition`을 만들어주고, INTERACTIVE는 이 y 좌표를 back-edge 판정 기준으로 사용합니다.

## 검증

**동일 E2E (`flow-login-01`, `--skip-rubric`) Before/After 비교**

Before:
- 좌표: `input` y=591 (최하단), `validate` y=12 (최상단과 동급)
- 시각: `시작`이 top-left에 고립되고 `input`이 bottom에 놓여 화살표가 그래프 전체를 세로로 가로지름
- `concept_coverage`: 0.75

After:
- 좌표: `시작` y=12 → `input` y=164 → `validate` y=289 (자연스러운 하향 흐름)
- 시각: 위→아래 흐름, 재시도 edge가 back-edge로 적절히 위로 꺾임
- `concept_coverage`: 1.0

**테스트**

- 기존 `elkEngine.test.ts` 6개 테스트 그대로 통과
- 회귀 방지용 테스트 1개 추가 (두 개의 retry loop가 `input`에 수렴하는 토폴로지 고정)
- `pnpm -r test`, `pnpm -r typecheck` 전체 통과

## Test plan

- [x] `pnpm --filter @drawcast/core test` — 104/104 passed
- [x] `pnpm typecheck` — 5/5 packages pass
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` — 렌더 성공, concept coverage 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flowchart layout handling for diagrams with multiple retry paths. The layout engine now better preserves intended node ordering in complex flowcharts, preventing unintended reordering that could occur with certain cycle-breaking scenarios.

* **Tests**
  * Added regression test for flowchart layouts with multiple retry paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->