### PR TITLE
fix(core): reserve ELK space for edge labels in dense feedback flowcharts

### DIFF
--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -65,7 +65,7 @@ export function buildGraphModel(
 
   for (const primitive of primitives) {
     if (primitive.kind === 'connector') {
-      const edge = connectorToEdge(primitive, nodeIds);
+      const edge = connectorToEdge(primitive, nodeIds, scene.theme);
       if (edge !== null) edges.push(edge);
     }
   }
@@ -164,6 +164,7 @@ function measureLabelBoxSize(
 function connectorToEdge(
   primitive: Extract<Primitive, { kind: 'connector' }>,
   knownNodeIds: ReadonlySet<string>,
+  theme: Theme,
 ): GraphEdge | null {
   // Only id-bound connectors participate. Raw Point endpoints are for
   // floating annotation arrows and must not influence layered layout.
@@ -175,10 +176,30 @@ function connectorToEdge(
   if (!knownNodeIds.has(primitive.from) || !knownNodeIds.has(primitive.to)) {
     return null;
   }
-  return {
+  const edge: GraphEdge = {
     id: primitive.id,
     source: primitive.from,
     target: primitive.to,
     routing: 'orthogonal',
   };
+  // Measure label so ELK's layered algorithm can reserve space for it.
+  // Without this the emitted text — which Excalidraw repositions to the
+  // arrow midpoint — ends up on top of nearby nodes in dense graphs
+  // (e.g. the retry-heavy CI flowchart where multiple "실패" labels
+  // cluster around a single "fix & re-push" target).
+  if (primitive.label !== undefined && primitive.label !== '') {
+    const fontSize = theme.defaultFontSize;
+    const fontFamily = theme.defaultFontFamily;
+    const metrics = measureText({
+      text: primitive.label,
+      fontSize,
+      fontFamily,
+    });
+    edge.label = {
+      text: primitive.label,
+      width: metrics.width,
+      height: metrics.height,
+    };
+  }
+  return edge;
 }

--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -10,6 +10,7 @@ import ElkConstructor, {
   type ELK,
   type ElkEdgeSection,
   type ElkExtendedEdge,
+  type ElkLabel,
   type ElkNode,
   type ElkPoint,
   type ElkPort,
@@ -84,6 +85,13 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
   'elk.layered.layering.strategy': 'LONGEST_PATH_SOURCE',
   'elk.layered.cycleBreaking.strategy': 'INTERACTIVE',
+  // Edge labels travel through the graph model carrying measured size
+  // (see buildGraphModel.ts). `edgeLabelSpacing` gives the routing pass
+  // enough perpendicular slack that the label — which Excalidraw pins
+  // to the arrow midpoint at render time — doesn't crash into nodes or
+  // other labels when many feedback edges converge on one target.
+  'elk.layered.spacing.edgeLabelSpacing': '12',
+  'elk.spacing.edgeLabel': '8',
   'elk.randomSeed': '1',
 };
 
@@ -155,11 +163,20 @@ function toElkPort(port: GraphPort): ElkPort {
 }
 
 function toElkEdge(edge: GraphEdge): ElkExtendedEdge {
-  return {
+  const out: ElkExtendedEdge = {
     id: edge.id,
     sources: [edge.sourcePort ?? edge.source],
     targets: [edge.targetPort ?? edge.target],
   };
+  if (edge.label !== undefined) {
+    const label: ElkLabel = {
+      text: edge.label.text,
+      width: edge.label.width,
+      height: edge.label.height,
+    };
+    out.labels = [label];
+  }
+  return out;
 }
 
 function fromElkResult(original: GraphModel, result: ElkNode): LaidOutGraph {

--- a/packages/core/src/layout/graph.ts
+++ b/packages/core/src/layout/graph.ts
@@ -73,6 +73,16 @@ export interface GraphEdge {
   targetPort?: string;
   routing?: EdgeRouting;
   protocol?: EdgeProtocol;
+  /** Measured label dimensions (see buildGraphModel.ts). Passing the
+   *  label size to ELK lets the layered algorithm reserve space along
+   *  the edge so the label — which Excalidraw renders at the arrow
+   *  midpoint — doesn't land on top of a node or another label in
+   *  retry-heavy flowcharts. */
+  label?: {
+    text: string;
+    width: number;
+    height: number;
+  };
 }
 
 export interface GraphModel {


### PR DESCRIPTION
## Summary
- `GraphEdge` 가 connector label 의 **text/width/height** 를 실어 ELK 로 넘긴다 (`buildGraphModel` 에서 scene theme 폰트로 측정).
- `toElkEdge` 가 `ElkExtendedEdge.labels` 을 채우고, 기본 layout options 에 `elk.spacing.edgeLabel` / `elk.layered.spacing.edgeLabelSpacing` 을 추가해 routing 이 label 공간을 예약하도록 한다.
- 결과적으로 "실패", "재시도", "거절" 같은 edge label 이 노드 위나 다른 label 위에 겹치는 문제가 완화된다.

## 배경
지금까지 `GraphEdge` 는 connector 의 label 을 버렸고, `toElkEdge` 는 `{sources, targets}` 만 담은 plain edge 를 내보냈다. ELK layered 알고리즘은 label 이 있는지도 몰랐으므로 재시도·피드백이 많은 플로우차트에서 label 공간을 전혀 확보하지 않았고, Excalidraw 는 bound arrow label 을 polyline 중점에 강제로 붙이기 때문에 label 이 인접 노드 위에 얹히거나 다른 label 과 포개지곤 했다.

## E2E 증거 (evals runner · claude CLI + drawcast MCP)
`flow-ci-04` (CI/CD 골든 질문, `--id flow-ci-04` 로 단일 실행):

| 시점 | total | layout | readability | rubric 지적 |
|---|---:|---:|---:|---|
| 수정 전 | **0.762** | 2 | 2 | "실패 분기들이 좌측에 과하게 겹쳐 있어..." |
| 수정 후 (run A) | **0.905** | 2 | 2 | major issues 없음 (minor 만 남음) |
| 수정 후 (run B) | **0.952** | 3 | 2 | layout perfect |

각 런의 score/scene/PNG 은 `evals/results/2026-04-*` 에 저장되어 있다.

## Test plan
- [x] `pnpm --filter @drawcast/core test` (104/104 통과)
- [x] `pnpm --filter @drawcast/core build` — 타입 체크 및 빌드 이상 없음
- [x] `pnpm --filter drawcast-evals eval -- --id flow-ci-04` 총 3회 재실행 (2 pass · 1 fail; 실패 샘플은 Claude 가 text·fill 색을 동일하게 뽑은 스타일 이슈로 본 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Edge labels now support automatic text measurement and dimension tracking during graph layout processing
  * Graph layout engine now incorporates measured label dimensions into spacing and routing calculations to improve readability and prevent overlap
  * Additional edge label spacing configuration options added for enhanced layout control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->