### PR TITLE
fix(core): force high-contrast dark for edge label text

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -41,6 +41,10 @@ const PARALLEL_LANE_SPACING = 120;
 // lifting for the common shape-to-shape case.
 const PARALLEL_LABEL_AXIS_OFFSET = 0.15;
 
+// High-contrast dark used for every edge label so red/muted/accent edges
+// don't produce low-contrast bound text.
+const EDGE_LABEL_TEXT_COLOR = '#1e1e1e';
+
 export interface ConnectorLane {
   /** 0-based index of this connector within its parallel group. */
   index: number;
@@ -425,7 +429,11 @@ export function emitConnector(
       width: metrics.width,
       height: metrics.height,
       angle: 0 as Radians,
-      strokeColor: style.strokeColor,
+      // Edge labels always render in a high-contrast dark color, not the
+      // edge's stroke color. Tinted edges (accent/muted/custom) drag label
+      // text below AA contrast against the canvas, and VLM rubrics flag the
+      // resulting short labels ("재입력", "재발송", …) as illegible.
+      strokeColor: EDGE_LABEL_TEXT_COLOR,
       backgroundColor: 'transparent',
       fillStyle: 'solid',
       strokeWidth: style.strokeWidth,


### PR DESCRIPTION
## Summary
- Edge labels now render in `#1e1e1e` regardless of the connector's stroke color
- Fixes the low-contrast red/grey bound text on accent/muted/dashed edges that the VLM rubric repeatedly flagged (e.g. `재입력`, `재발송` on retry loops)

## Why
`connector.ts` copied `style.strokeColor` onto the bound text element. On tinted edges (accent red, muted grey, LLM-provided `#c62828`, …) that dragged every short label below AA contrast. The eval rubric's last `flow-signup-02` run called it out directly: _"좌측 보조 분기와 점선 경로의 텍스트(재입력, 재발송)가 작고 대비가 약해 한눈에 읽기 어렵다."_

Edge geometry still keeps its visual coding via the arrow stroke — we just stop propagating the color to the text that has to be read.

## Test plan
- [x] `pnpm --filter @drawcast/core test` — all 104 core tests pass
- [x] Rerun `pnpm --filter drawcast-evals eval -- --id flow-signup-02`: emitted scene shows `"strokeColor": "#1e1e1e"` on the `재입력` bound text, and the rubric's "대비가 약해" major-issue line is gone
- [x] Rerun `pnpm --filter drawcast-evals eval -- --id flow-login-01`: `무효 / 유효 / 성공 / 실패 / 재입력` edge labels render in solid dark; total score 1.0 (was 1.0 with dark-stroke default but 0.89 on tinted-edge run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)