### PR TITLE
fix(core): expand labelBox height so wrapped text stays inside the box

### DIFF
--- a/packages/core/src/emit/labelBox.ts
+++ b/packages/core/src/emit/labelBox.ts
@@ -19,7 +19,7 @@ import {
   type BaseElementFields,
 } from '../utils/baseElementFields.js';
 import { newElementId } from '../utils/id.js';
-import { getLineHeight, measureText } from '../measure.js';
+import { getLineHeight, measureText, type TextMetrics } from '../measure.js';
 import { wrapText } from '../wrap.js';
 import type {
   ExcalidrawDiamondElement,
@@ -92,6 +92,38 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
     }
   }
 
+  // Pre-wrap the text and expand the container height if the wrapped glyph
+  // run needs more vertical room than the declared box. Callers that pass
+  // fit:'fixed' with a height sized for the raw (unwrapped) line count —
+  // common with CJK labels that wrap into more lines once width is clamped —
+  // would otherwise overflow the shape and collide with neighbouring edge
+  // labels (see arch-cdn-03 eval: "PostgreSQL" spilled into a nearby
+  // "replicate" label below the Main DB node).
+  let prewrappedText: string | undefined;
+  let prewrappedMetrics: TextMetrics | undefined;
+  if (p.text) {
+    const maxTextWidth = Math.max(width - padding * 2, 1);
+    prewrappedText = wrapText({
+      text: p.text,
+      maxWidth: maxTextWidth,
+      fontSize,
+      fontFamily,
+    });
+    prewrappedMetrics = measureText({
+      text: prewrappedText,
+      fontSize,
+      fontFamily,
+      lineHeight,
+    });
+    // Only expand when the wrapped text itself would not fit — the caller's
+    // declared height already accounts for their preferred padding, so a
+    // single-line label in an 80×40 box should stay 80×40 rather than grow
+    // to include an extra 20px top/bottom of reserved padding.
+    if (prewrappedMetrics.height > height) {
+      height = prewrappedMetrics.height + padding * 2;
+    }
+  }
+
   // -- Roundness (P10 matrix) --------------------------------------------------
   // rectangle / diamond accept {type:3}. ellipse always null (ignored anyway).
   let roundness: Roundness = null;
@@ -144,19 +176,24 @@ export function emitLabelBox(p: LabelBox, ctx: CompileContext): void {
   // -- Text child (if any) -----------------------------------------------------
   let textId: string | null = null;
   if (p.text) {
-    const maxTextWidth = Math.max(width - padding * 2, 1);
-    const wrapped = wrapText({
-      text: p.text,
-      maxWidth: maxTextWidth,
-      fontSize,
-      fontFamily,
-    });
-    const wrappedMetrics = measureText({
-      text: wrapped,
-      fontSize,
-      fontFamily,
-      lineHeight,
-    });
+    // Reuse the pre-wrap computed above for the height fit-up decision so
+    // the text element and the container stay in lock-step.
+    const wrapped =
+      prewrappedText ??
+      wrapText({
+        text: p.text,
+        maxWidth: Math.max(width - padding * 2, 1),
+        fontSize,
+        fontFamily,
+      });
+    const wrappedMetrics =
+      prewrappedMetrics ??
+      measureText({
+        text: wrapped,
+        fontSize,
+        fontFamily,
+        lineHeight,
+      });
 
     // Size the text element to its measured glyph run (plus a single-pixel
     // safety margin so aliasing doesn't clip edges) and center it inside

--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -11,6 +11,7 @@
 // caller falls back to the synchronous compile path.
 
 import { measureText } from '../measure.js';
+import { wrapText } from '../wrap.js';
 import type { LabelBox, Primitive, Scene } from '../primitives.js';
 import type { Theme } from '../theme.js';
 import type { GraphEdge, GraphModel, GraphNode } from './graph.js';
@@ -120,31 +121,32 @@ function measureLabelBoxSize(
   primitive: LabelBox,
   theme: Theme,
 ): { width: number; height: number } {
-  // fit:'fixed' pins the declared size through emit. Mirror the emit
-  // fallback when size is missing rather than measure (users who opt
-  // into fixed are signalling "don't auto-fit").
-  if (primitive.fit === 'fixed') {
-    if (primitive.size !== undefined) {
-      return { width: primitive.size[0], height: primitive.size[1] };
-    }
-    return { width: FIXED_FALLBACK_WIDTH, height: FIXED_FALLBACK_HEIGHT };
-  }
-
-  // Auto (default). An explicit size wins over measurement so caller
-  // overrides aren't silently discarded.
-  if (primitive.size !== undefined) {
-    return { width: primitive.size[0], height: primitive.size[1] };
-  }
-
-  // No size: measure the raw text and pad, matching emitLabelBox's
-  // own auto-fit rule. Wrapping isn't applied here — we don't yet
-  // know a target max width, so we reserve the whole unwrapped run.
   const fontSize = primitive.fontSize ?? theme.defaultFontSize;
   const fontFamily = primitive.fontFamily ?? theme.defaultFontFamily;
 
-  let width = MIN_LAYOUT_WIDTH;
-  let height = MIN_LAYOUT_HEIGHT;
-  if (primitive.text !== undefined && primitive.text !== '') {
+  let width: number;
+  let height: number;
+
+  if (primitive.fit === 'fixed') {
+    // fit:'fixed' pins the declared width through emit. Mirror the emit
+    // fallback when size is missing rather than measure (users who opt
+    // into fixed are signalling "don't auto-fit" the width).
+    if (primitive.size !== undefined) {
+      width = primitive.size[0];
+      height = primitive.size[1];
+    } else {
+      width = FIXED_FALLBACK_WIDTH;
+      height = FIXED_FALLBACK_HEIGHT;
+    }
+  } else if (primitive.size !== undefined) {
+    // Auto fit but caller handed us an explicit size; don't silently
+    // discard it.
+    width = primitive.size[0];
+    height = primitive.size[1];
+  } else if (primitive.text !== undefined && primitive.text !== '') {
+    // No size: measure the raw text and pad, matching emitLabelBox's
+    // own auto-fit rule. Wrapping isn't applied here — we don't yet
+    // know a target max width, so we reserve the whole unwrapped run.
     const metrics = measureText({
       text: primitive.text,
       fontSize,
@@ -152,6 +154,34 @@ function measureLabelBoxSize(
     });
     width = Math.max(metrics.width + LAYOUT_PADDING * 2, MIN_LAYOUT_WIDTH);
     height = Math.max(metrics.height + LAYOUT_PADDING * 2, MIN_LAYOUT_HEIGHT);
+  } else {
+    width = MIN_LAYOUT_WIDTH;
+    height = MIN_LAYOUT_HEIGHT;
+  }
+
+  // Guarantee the reserved box can contain the wrapped glyph run. A
+  // caller that pins width via fit:'fixed' still expects text to fit;
+  // CJK labels frequently wrap into more lines than the raw height was
+  // sized for, and without this the emit layer renders text spilling
+  // below the shape into nearby edge labels (arch-cdn-03 eval).
+  if (primitive.text !== undefined && primitive.text !== '') {
+    const maxTextWidth = Math.max(width - LAYOUT_PADDING * 2, 1);
+    const wrapped = wrapText({
+      text: primitive.text,
+      maxWidth: maxTextWidth,
+      fontSize,
+      fontFamily,
+    });
+    const wrappedMetrics = measureText({
+      text: wrapped,
+      fontSize,
+      fontFamily,
+    });
+    // Only expand when the wrapped text itself would not fit — the
+    // declared height already includes the caller's preferred padding.
+    if (wrappedMetrics.height > height) {
+      height = wrappedMetrics.height + LAYOUT_PADDING * 2;
+    }
   }
 
   if (primitive.shape !== 'rectangle') {

--- a/packages/core/test/buildGraphModel.test.ts
+++ b/packages/core/test/buildGraphModel.test.ts
@@ -96,18 +96,37 @@ describe('buildGraphModel — labelBox size measurement', () => {
     expect(n.height).toBe(MIN_H);
   });
 
-  it('honours an explicit size without remeasuring', () => {
+  it('honours an explicit width but grows height so wrapped text fits', () => {
     const box: LabelBox = {
       kind: 'labelBox',
       id: 'sized' as PrimitiveId,
       shape: 'rectangle',
       size: [200, 80],
-      text: 'x'.repeat(500), // huge text — would blow past 200 if we measured
+      text: 'x'.repeat(500), // huge text — wraps many times at width 200
     };
     const graph = buildGraphModel(makeScene([box]));
     const n = node('sized', graph);
+    // Width stays pinned so the caller's horizontal layout intent is kept.
     expect(n.width).toBe(200);
-    expect(n.height).toBe(80);
+    // Height grows so ELK reserves enough vertical space for the wrapped
+    // glyph run; otherwise the emitted text spills past the reserved box
+    // and collides with neighbouring nodes/edge labels.
+    expect(n.height).toBeGreaterThan(80);
+  });
+
+  it('keeps the declared height when the text already fits', () => {
+    const box: LabelBox = {
+      kind: 'labelBox',
+      id: 'snug' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [120, 40],
+      text: 'ok',
+    };
+    const graph = buildGraphModel(makeScene([box]));
+    const n = node('snug', graph);
+    expect(n.width).toBe(120);
+    expect(n.height).toBe(40);
   });
 
   it('uses the fixed-fit fallback when fit:"fixed" arrives without size', () => {

--- a/packages/core/test/emit-labelBox.test.ts
+++ b/packages/core/test/emit-labelBox.test.ts
@@ -119,14 +119,43 @@ describe('emitLabelBox — container-bound text geometry (B1)', () => {
       (e): e is ExcalidrawTextElement => e.type === 'text',
     )!;
 
+    // Width stays pinned to the fit:'fixed' request; height can grow so
+    // the wrapped glyph run is contained (see emit/labelBox.ts comment).
     expect(shape.width).toBe(120);
-    expect(shape.height).toBe(80);
+    expect(shape.height).toBeGreaterThanOrEqual(80);
     // Text fits inside.
-    expect(text.width).toBeLessThanOrEqual(120);
-    expect(text.height).toBeLessThanOrEqual(80);
+    expect(text.width).toBeLessThanOrEqual(shape.width);
+    expect(text.height).toBeLessThanOrEqual(shape.height);
     // Centred (to within rounding).
     expect(text.x + text.width / 2).toBeCloseTo(shape.x + shape.width / 2, 1);
     expect(text.y + text.height / 2).toBeCloseTo(shape.y + shape.height / 2, 1);
+  });
+
+  it('expands fixed-height box so wrapped text does not overflow', () => {
+    // Regression: arch-cdn-03 eval showed "Main DB (Primary)\nPostgreSQL"
+    // wrapping into 3 lines inside a fit:'fixed' [200, 65] box, so the
+    // "PostgreSQL" line spilled below the shape onto a nearby edge label.
+    const p: LabelBox = {
+      kind: 'labelBox',
+      id: 'main_db' as PrimitiveId,
+      shape: 'rectangle',
+      at: [0, 0],
+      fit: 'fixed',
+      size: [200, 65],
+      text: 'Main DB (Primary)\nPostgreSQL',
+    };
+    const result = compile(makeScene([p]));
+    const shape = result.elements.find(
+      (e): e is ExcalidrawRectangleElement => e.type === 'rectangle',
+    )!;
+    const text = result.elements.find(
+      (e): e is ExcalidrawTextElement => e.type === 'text',
+    )!;
+    // The container must be tall enough that the wrapped text fits inside.
+    expect(shape.height).toBeGreaterThan(65);
+    expect(text.height).toBeLessThanOrEqual(shape.height);
+    // The text bottom stays within the shape bottom.
+    expect(text.y + text.height).toBeLessThanOrEqual(shape.y + shape.height + 1);
   });
 
   it('shape still registers the text in boundElements so Excalidraw pairs them', () => {


### PR DESCRIPTION
## Summary
- When a caller passed `fit:'fixed'` with a height sized for the raw (unwrapped) line count, CJK/mixed labels that wrapped into extra lines rendered past the shape bottom and collided with nearby edge labels.
- `emitLabelBox` and `measureLabelBoxSize` now pre-wrap the text and grow the declared height to `wrapped.height + padding*2` when the wrapped run exceeds the declared height. Width stays pinned so horizontal layout intent is preserved.
- Tests updated: the previous \"declared size is sacred\" fixtures relaxed, plus a new regression test pinning the arch-cdn-03 scenario (200×65 Main DB box containing two-line text that wraps into three).

## Verification
- `pnpm --filter @drawcast/core test` — 106 tests pass (including the new regression).
- E2E: `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --n 1` before vs. after. Before: rubric major issue \"중앙 DB 주변의 PostgreSQL/replicate 텍스트가 겹쳐…\". After: that overlap is gone; the Main DB box grew tall enough to hold its full label and the \"replicate\" edge labels sit cleanly on their own arrows.
- Full suite: `pnpm -r test` — 303/303 pass.

## Test plan
- [x] `pnpm --filter @drawcast/core test`
- [x] `pnpm -r test`
- [x] `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --n 1` — no regression, specific overlap fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label boxes now intelligently wrap long text and automatically expand container height to ensure all wrapped content fits properly within boundaries.

* **Bug Fixes**
  * Fixed text measurement and centering calculations to remain consistent with dynamically expanded containers, preventing text overflow.

* **Tests**
  * Added new regression tests and updated existing test cases to validate proper text wrapping behavior and containment in fixed-size labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->