### PR TITLE
fix(core): widen ELK edge-edge spacing for parallel arrow labels

### DIFF
--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -92,6 +92,16 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   // other labels when many feedback edges converge on one target.
   'elk.layered.spacing.edgeLabelSpacing': '12',
   'elk.spacing.edgeLabel': '8',
+  // Parallel arrows between the same node pair (e.g. request/response in
+  // arch-3tier-01) end up only ~30px apart on each side of the boundary
+  // with ELK's default port distribution. Bound text labels are pinned
+  // to the arrow midpoint by Excalidraw, so when the perpendicular gap
+  // is narrower than the label width the two label runs overlap
+  // ("HTTP 응답HTTP 요청"). Bumping `spacing.edgeEdge` widens the lane
+  // so labels stop crashing into one another while still keeping
+  // architecture diagrams compact.
+  'elk.spacing.edgeEdge': '120',
+  'elk.layered.spacing.edgeEdgeBetweenLayers': '40',
   'elk.randomSeed': '1',
 };
 


### PR DESCRIPTION
## Summary

- Bidirectional connectors between the same two nodes (e.g. HTTP request/response in `arch-3tier-01`) only got ~30px of perpendicular spacing because ELK's default `spacing.edgeEdge` is 10. Excalidraw pins bound text to each arrow's midpoint at render time, so the two label runs collided ("HTTP 응답HTTP 요청"). Bumped `elk.spacing.edgeEdge` to 120 (and added a modest `edgeEdgeBetweenLayers` of 40) to widen the lane.

## Before / After

| Before | After |
|---|---|
| Labels overlap on parallel arrows. | Each label sits on its own arrow with clean separation. |

Verified by re-running the eval harness against `arch-3tier-01`, `flow-login-01`, and `arch-cdn-03`. `pnpm --filter @drawcast/core test` (106 tests) still passes.

## Test plan

- [x] `pnpm --filter @drawcast/core build`
- [x] `pnpm --filter @drawcast/core test`
- [x] `pnpm --filter drawcast-evals eval -- --id arch-3tier-01 --skip-rubric` — labels no longer overlap
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` — flowchart still renders cleanly
- [x] `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --skip-rubric` — no regression in dense architecture diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)