### PR TITLE
fix(mcp-server): tell drawing agent to stay in scope

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -57,7 +57,8 @@ const DEFAULT_INSTRUCTIONS = `You are drawing a diagram into a shared Excalidraw
 3. Keep edge labels short (≤8 chars, e.g. "예"/"아니오"/"success"/"fail"). Long labels collide with neighbouring boxes; move detail into the connected box's text instead.
 4. Branches go in their own columns. For decision diamonds, place the "yes" child and "no" child in different columns at the same y row, then merge below if needed.
 5. Upsert ids should be stable — re-upserting the same id repositions rather than duplicating. Prefer getting coordinates right the first time over iterative nudges.
-6. End the session as soon as the diagram is complete. The host runner fetches the scene via draw_export automatically, so you do not need to call draw_export yourself unless asked.`;
+6. Stay in scope. Draw only the elements the user explicitly asked for; do not invent retry loops, validation retries, logging, or "end/terminate" nodes that were not requested. If the prompt lists N steps, N boxes plus one start/end node each is usually enough — prefer 5–8 boxes for a simple flow over 10+. Adding undemanded branches clutters the layout and hurts readability more than it adds information.
+7. End the session as soon as the diagram is complete. The host runner fetches the scene via draw_export automatically, so you do not need to call draw_export yourself unless asked.`;
 
 export function createServer(options: CreateServerOptions = {}): DrawcastServer {
   const name = options.name ?? DEFAULT_NAME;


### PR DESCRIPTION
## Summary
- Add a \"stay in scope\" rule (#6) to the drawcast MCP `initialize` instructions so the drawing agent draws only elements the prompt asked for, instead of auto-inventing retry loops, validation retries, logging, or terminator nodes.
- Motivated by an eval regression on simple flowcharts: on `flow-login-01` the agent was emitting 12 nodes / 14 edges against the golden-set band of 5–9 / 4–10, producing `node_count_fit=0` and `edge_count_fit=0` in the rule track.

## Evidence

Same question, same model, with only the instruction change:

| | node_count | edge_count | node_count_fit | edge_count_fit | overlap_pairs | concept_coverage |
|---|---:|---:|---:|---:|---:|---:|
| before | 12 | 14 | 0 | 0 | 0 | 1.0 |
| after  |  8 |  8 | **1** | **1** | 0 | 1.0 |

Renders are attached in the eval artifacts (`evals/results/2026-04-21T14-02-34Z` vs `…T14-06-51Z`) — the \"after\" diagram drops the uncommissioned `재시도?` diamond + extra error path and keeps the branch the prompt actually asked for (`성공` / `실패`).

## Test plan
- [x] `pnpm --filter @drawcast/mcp-server test` (131 passed)
- [x] Run `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` twice; both runs fit the expected node/edge bands.
- [ ] Optional follow-up: rerun the full 20-question baseline to confirm the structure/readability axes improve without regressions in the `hard` bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagram generation to prioritize user-requested elements only, avoiding unnecessary additions like retry logic, validation nodes, or logging constructs that could clutter layouts.
  * Diagrams now maintain simpler, cleaner layouts by focusing on core flow elements without undemanded branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->