### PR TITLE
fix(core): wrap long linear flows so they stop rendering ~4x taller than wide

### DIFF
--- a/packages/core/src/layout/elkEngine.ts
+++ b/packages/core/src/layout/elkEngine.ts
@@ -102,6 +102,18 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   // architecture diagrams compact.
   'elk.spacing.edgeEdge': '120',
   'elk.layered.spacing.edgeEdgeBetweenLayers': '40',
+  // Long mostly-linear flows (CI/CD pipelines, multi-step checklists, etc.)
+  // produced diagrams that were ~4x taller than wide, forcing rubric
+  // reviewers to scroll and burying context ("실패 경로 점선이 좌우로 크게
+  // 우회" in flow-ci-04 baseline). SINGLE_EDGE wrapping only kicks in when
+  // the natural layered result is taller than the target aspect ratio, so
+  // it leaves compact / branching graphs alone (verified on the 3-node
+  // arch-3tier-01 case and the 7-node retry flow) while wrapping chains
+  // of ≥5 nodes into two columns. Target 0.8 is intentionally below ELK's
+  // default 1.6 because flowcharts read fine portrait — we only want to
+  // cap the extreme tall-and-narrow case.
+  'elk.aspectRatio': '0.8',
+  'elk.layered.wrapping.strategy': 'SINGLE_EDGE',
   'elk.randomSeed': '1',
 };
 

--- a/packages/core/test/elkEngine.test.ts
+++ b/packages/core/test/elkEngine.test.ts
@@ -218,6 +218,68 @@ describe('ElkLayoutEngine', () => {
     }
   });
 
+  it('wraps long linear chains into columns so flowcharts do not end up ~4x taller than wide', async () => {
+    // Regression guard for the flow-ci-04 rubric finding that a 10-stage
+    // CI/CD flow rendered at aspect ratio ~0.40 (width/height), forcing
+    // reviewers to scroll. `elk.aspectRatio=0.8 + wrapping.strategy=
+    // SINGLE_EDGE` wraps chains of ≥5 nodes into two columns while leaving
+    // short or already-branching graphs alone (the other tests above
+    // continue to pass without wrapping).
+    const engine = new ElkLayoutEngine();
+    const children = Array.from({ length: 10 }, (_, i) => ({
+      id: `n${i}`,
+      primitiveIds: [`n${i}`],
+      width: 160,
+      height: 60,
+    }));
+    const edges = Array.from({ length: 9 }, (_, i) => ({
+      id: `e${i}`,
+      source: `n${i}`,
+      target: `n${i + 1}`,
+    }));
+    const graph: GraphModel = {
+      id: 'scene',
+      diagramType: 'flowchart',
+      children,
+      edges,
+    };
+    const result = await engine.layout(graph);
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const node of result.children) {
+      minX = Math.min(minX, node.x);
+      maxX = Math.max(maxX, node.x + node.width);
+      minY = Math.min(minY, node.y);
+      maxY = Math.max(maxY, node.y + node.height);
+    }
+    const width = maxX - minX;
+    const height = maxY - minY;
+    // Without wrapping, a 10-node chain with 60px-tall boxes + 60px
+    // spacing would be ~1140px tall and only 160px wide (ratio ~0.14).
+    // After wrapping into two columns it should be no taller than it is
+    // without wrapping, and at least ~2x wider.
+    expect(height).toBeLessThan(700);
+    expect(width).toBeGreaterThan(300);
+    // More than one distinct x-bucket proves the chain is no longer a
+    // single vertical column.
+    const distinctXs = new Set(result.children.map((n) => Math.round(n.x)));
+    expect(distinctXs.size).toBeGreaterThan(1);
+  });
+
+  it('leaves short chains in a single column (does not wrap prematurely)', async () => {
+    // Safety net for the wrapping config: the 3-node lineGraph fixture
+    // represents the typical 3-tier architecture case (arch-3tier-01).
+    // SINGLE_EDGE wrapping with aspectRatio=0.8 must NOT turn it into a
+    // horizontal L-shape — users and the rubric expect a simple vertical
+    // flow here.
+    const engine = new ElkLayoutEngine();
+    const result = await engine.layout(lineGraph());
+    const distinctXs = new Set(result.children.map((n) => Math.round(n.x)));
+    expect(distinctXs.size).toBe(1);
+  });
+
   it('accepts fixedPosition input without failing layout', async () => {
     // Layered algorithm recomputes positions globally and only treats
     // `elk.position` as a soft hint, so we don't yet guarantee the


### PR DESCRIPTION
## Summary

- `evals/flow-ci-04` baseline rendered at aspect ratio ~0.40 (482×1220). Rubric flagged it as "세로로 매우 길고 폭이 좁아 전체 흐름을 한눈에 따라가기 어렵다".
- Added `elk.aspectRatio=0.8` + `elk.layered.wrapping.strategy=SINGLE_EDGE` so ELK wraps chains of ≥5 nodes into two columns; short chains and already-branching graphs are untouched.
- Two new regression tests pin both ends of the threshold in [packages/core/test/elkEngine.test.ts](packages/core/test/elkEngine.test.ts).

## Evidence

Deterministic layout probe on a 10-node linear chain (same shape as flow-ci-04):

| config | width × height | ratio |
|---|---|---|
| default | 160 × 1140 | 0.14 |
| **new** | 361 × 540 | **0.67** |

Probe on 3-node chain (arch-3tier-01 shape) and retry flow (7 nodes with branches): **unchanged** — wrap does not trigger.

E2E:
- `flow-retry-05`: layout=3/3 (max), total=0.905 — no regression
- `flow-ci-04`: layout=2/3 — unchanged; structure/intent_fit variance dominated this one run (AI non-determinism)

## Test plan

- [x] `pnpm --filter @drawcast/core test` — 111 passed (109 existing + 2 new)
- [x] `pnpm --filter drawcast-evals eval -- --id flow-retry-05` — pass 0.905
- [x] `pnpm --filter drawcast-evals eval -- --id flow-ci-04` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)