### PR TITLE
fix(core): anchor edge labels on the polyline midpoint

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -56,6 +56,31 @@ function centerOfRecord(record: PrimitiveRecord): Point {
   return [record.bbox.x + record.bbox.w / 2, record.bbox.y + record.bbox.h / 2];
 }
 
+/**
+ * Pick a label anchor on the edge polyline that matches Excalidraw 0.17.x's
+ * own `getBoundTextElementPosition` logic: odd-count → the middle waypoint,
+ * even-count → the midpoint of the middle segment. For 2-point (straight)
+ * routes this collapses to the straight-line midpoint, so existing call
+ * sites behave identically. Routed polylines (elbow, ELK `routedPath`)
+ * land the label on the segment that actually carries the drawn edge
+ * instead of floating at the diagonal midpoint between shapes.
+ */
+function computeLabelAnchor(points: readonly Point[]): Point {
+  if (points.length === 0) return [0, 0];
+  if (points.length === 1) {
+    const only = points[0]!;
+    return [only[0], only[1]];
+  }
+  if (points.length % 2 === 1) {
+    const mid = points[Math.floor(points.length / 2)]!;
+    return [mid[0], mid[1]];
+  }
+  const i = points.length / 2 - 1;
+  const a = points[i]!;
+  const b = points[i + 1]!;
+  return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+}
+
 function isPoint(ref: PrimitiveId | Point): ref is Point {
   return typeof ref !== 'string';
 }
@@ -398,13 +423,23 @@ export function emitConnector(
     const fontSize = style.fontSize ?? ctx.theme.defaultFontSize;
     const lineHeight = getLineHeight(fontFamily);
     const metrics = measureText({ text: p.label, fontSize, fontFamily });
-    // Midpoint of the (shifted) endpoints. For parallel connectors we also
-    // slide the label along the pair's *canonical* axis so opposite-direction
-    // labels don't land at identical coordinates (midpoint ± offset along
-    // each arrow's own direction cancels out — the two arrows share a
-    // midpoint). Using the canonical axis breaks that symmetry.
-    const mx = (start[0] + end[0]) / 2;
-    const my = (start[1] + end[1]) / 2;
+    // Anchor on the polyline, not the straight line between endpoints.
+    // For orthogonally routed feedback edges (ELK `routedPath`, or the
+    // built-in elbow router) the straight-line midpoint can fall far off
+    // the visible edge path — e.g. the "재시도" label in flow-login-01
+    // was floating in open space between shapes. Matching Excalidraw
+    // 0.17.x's own `getBoundTextElementPosition` (odd points → middle
+    // point; even points → middle-segment midpoint) keeps the emit-time
+    // position consistent with how the editor repositions the label on
+    // interaction, and lands labels on the segment that actually carries
+    // the edge.
+    //
+    // For parallel connectors we additionally slide the label along the
+    // pair's *canonical* axis so opposite-direction labels don't land at
+    // identical coordinates (midpoint ± offset along each arrow's own
+    // direction cancels out — the two arrows share a midpoint). Using
+    // the canonical axis breaks that symmetry.
+    const [mx, my] = computeLabelAnchor(rawPoints);
     const dxFull = end[0] - start[0];
     const dyFull = end[1] - start[1];
     const lenFull = Math.hypot(dxFull, dyFull);

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -426,6 +426,72 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     expect(labelXs[0]).not.toBe(labelXs[1]);
   });
 
+  it('routedPath label anchors on the middle segment, not the endpoint midpoint', () => {
+    // Regression for "재시도" / feedback-edge labels floating off-path. A
+    // 6-point ELK-routed feedback edge has endpoints far apart horizontally
+    // (~200px) but the actual drawn path runs as a narrow L along x≈9.
+    // The straight-line midpoint would land at x≈99 in open space; the
+    // real edge has no ink there and readers can't tell which arrow the
+    // label belongs to. Anchoring on the middle segment (matching
+    // Excalidraw 0.17.x's own bound-text logic) keeps the label on the
+    // segment that carries the edge.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [0, 400],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'b' as PrimitiveId,
+      to: 'a' as PrimitiveId,
+      label: '재시도',
+      routing: 'elbow',
+      routedPath: [
+        [84, 526],
+        [84, 476],
+        [93, 476],
+        [93, 239],
+        [281.83, 239],
+        [281.83, 229],
+      ],
+    };
+    const result = compile(makeScene([a, b, c]));
+    const label = result.elements.find(
+      (el): el is {
+        type: 'text';
+        text: string;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      } => el.type === 'text' && (el as { text?: string }).text === '재시도',
+    );
+    if (label === undefined) {
+      throw new Error('expected label element');
+    }
+    const centerX = label.x + label.width / 2;
+    const centerY = label.y + label.height / 2;
+    // Middle segment of the 6-point path is points[2]→points[3] = (93,476)→(93,239).
+    // Midpoint = (93, 357.5). The straight-line midpoint between waypoints[0]
+    // and waypoints[5] would be (182.9, 377.5) — off in open space.
+    expect(centerX).toBe(93);
+    expect(centerY).toBeCloseTo(357.5, 5);
+  });
+
   it('raw Point endpoints are passed through unchanged (no boundary math)', () => {
     const c: Connector = {
       kind: 'connector',


### PR DESCRIPTION
## Summary
- Edge labels now anchor on the polyline (odd → middle waypoint; even → middle-segment midpoint) instead of the straight-line midpoint between arrow endpoints.
- Matches Excalidraw 0.17.x's own `getBoundTextElementPosition` rule, so the emit-time position is consistent with how the editor repositions labels on interaction.
- Straight 2-point connectors and parallel-lane axis shifts are unaffected — the change only moves labels for routed polylines (ELK `routedPath` or the built-in elbow router).

## Why
For orthogonally routed feedback edges the straight-line midpoint can fall far off the drawn path. On `flow-login-01` the "재시도" label floated in open space between shapes while the actual dashed edge ran down the left side of the canvas — readers couldn't tell which arrow the label belonged to.

### Before / After (flow-login-01)

| Before | After |
|---|---|
| "재시도" label floating at the diagonal midpoint (~x=183), nowhere near the dashed edge path at x≈93 | "재시도" label sits alongside the vertical dashed segment |

## Test plan
- [x] New unit test: `emit-connector.test.ts` — 6-point ELK-routed feedback edge anchors label at the middle-segment midpoint (93, 357.5), not the diagonal midpoint (~183, 377.5).
- [x] All 114 core tests pass (`pnpm --filter @drawcast/core test`).
- [x] `pnpm -r test` green across core / mcp-server / app (311 tests total).
- [x] E2E re-run on `flow-login-01` — rubric total stays at 1.0; visual diff confirms label is now on the edge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector label positioning to use intelligent anchoring along the connector's path instead of simple endpoint midpoint calculation, ensuring labels display at the appropriate location even for complex routed connectors.

* **Tests**
  * Added regression test to verify correct label positioning behavior on connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->