### PR TITLE
fix(core): detour straight connectors around LabelBoxes they cross

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -230,6 +230,177 @@ function canonicaliseDirection(dx: number, dy: number): [number, number] {
   return dy >= 0 ? [dx, dy] : [-dx, -dy];
 }
 
+// Margin added on top of an obstacle's bbox when detouring an axis-aligned
+// straight connector around it. Chosen to leave a visible gap between the
+// detoured line and the node edge so edge labels (which Excalidraw pins to
+// the polyline midpoint) don't visually touch the bypassed node.
+const OBSTACLE_DETOUR_MARGIN = 20;
+
+interface ObstacleBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Liang–Barsky strict-interior test: does the segment `start → end` cross
+ * the interior of `b`, or only graze an edge? Returns true iff there is a
+ * sub-segment of non-trivial length lying strictly inside the bbox. Grazes
+ * and touches return false, so a connector whose endpoint sits flush with
+ * an obstacle edge (the normal boundary-to-boundary anchoring) doesn't
+ * trigger a detour.
+ */
+function segmentCrossesBBoxInterior(
+  start: Point,
+  end: Point,
+  b: ObstacleBBox,
+): boolean {
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  let t0 = 0;
+  let t1 = 1;
+  const clip = (p: number, q: number): boolean => {
+    if (Math.abs(p) < 1e-9) {
+      // Segment is parallel to this clip edge; inside iff q >= 0.
+      return q >= 0;
+    }
+    const r = q / p;
+    if (p < 0) {
+      if (r > t1) return false;
+      if (r > t0) t0 = r;
+    } else {
+      if (r < t0) return false;
+      if (r < t1) t1 = r;
+    }
+    return true;
+  };
+  if (!clip(-dx, start[0] - b.x)) return false;
+  if (!clip(dx, b.x + b.w - start[0])) return false;
+  if (!clip(-dy, start[1] - b.y)) return false;
+  if (!clip(dy, b.y + b.h - start[1])) return false;
+  // Require a non-trivial interior slice: excludes pure edge-grazes and
+  // segments that only touch a corner.
+  return t1 - t0 > 1e-3 && t0 < 1 - 1e-3 && t1 > 1e-3;
+}
+
+/**
+ * Scan the registry for a LabelBox whose bbox strictly crosses the straight
+ * segment from `start` to `end`, ignoring the endpoint-owning primitives
+ * themselves. Returns the first such obstacle or `null`.
+ *
+ * Phase 2 scope: only invoked on the sync compile path (no ELK routedPath)
+ * for `routing:'straight'` segments — ELK already routes around nodes, and
+ * elbow/curved paths already bend. Handles the common regression where an
+ * LLM stacks three nodes on the same axis ("Web → Redis → DB" in the
+ * arch-cdn-03 eval) and emits a straight arrow that skips the middle node:
+ * the line and its bound label render on top of the bypassed node's text.
+ */
+function findBlockingLabelBox(
+  start: Point,
+  end: Point,
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): ObstacleBBox | null {
+  for (const [id, record] of ctx.registry) {
+    if (excludeIds.has(id)) continue;
+    if (record.kind !== 'labelBox') continue;
+    if (segmentCrossesBBoxInterior(start, end, record.bbox)) return record.bbox;
+  }
+  return null;
+}
+
+/**
+ * Build an L-shaped detour around `obstacle` going via the single corner
+ * that lies on the far side of the obstacle relative to the straight line.
+ * The detour replaces a 2-point line with 3 points [start, corner, end];
+ * for axis-aligned inputs this generalises to 4 points [start, bend,
+ * bend, end] via the dedicated axis-aligned branch because pinning the
+ * corner on only one axis would rebuild the same vertical/horizontal
+ * crossing on the opposite edge.
+ *
+ * Strategy: try each of the 4 obstacle corners (inflated by a margin),
+ * filter to those whose two new sub-segments don't re-enter the obstacle,
+ * and pick the one with the shortest total length. Falls back to a 4-point
+ * axis-aligned bypass when no 3-point route clears the obstacle (this is
+ * the common case for a vertical or horizontal straight arrow that passed
+ * through the obstacle's full height/width).
+ */
+function detourAroundObstacle(
+  start: Point,
+  end: Point,
+  obstacle: ObstacleBBox,
+): Point[] {
+  const m = OBSTACLE_DETOUR_MARGIN;
+  const vertical = Math.abs(start[0] - end[0]) < 1e-6;
+  const horizontal = Math.abs(start[1] - end[1]) < 1e-6;
+  if (vertical || horizontal) {
+    // Axis-aligned inputs: a 3-point L can't help because the arrow's
+    // degenerate axis has to bend twice to clear both edges of the
+    // obstacle. Use the dedicated 4-point bypass that picks the side
+    // closer to the source endpoint.
+    if (vertical) {
+      const leftX = obstacle.x - m;
+      const rightX = obstacle.x + obstacle.w + m;
+      const detourX =
+        Math.abs(start[0] - leftX) < Math.abs(start[0] - rightX)
+          ? leftX
+          : rightX;
+      return [
+        [start[0], start[1]],
+        [detourX, start[1]],
+        [detourX, end[1]],
+        [end[0], end[1]],
+      ];
+    }
+    const topY = obstacle.y - m;
+    const botY = obstacle.y + obstacle.h + m;
+    const detourY =
+      Math.abs(start[1] - topY) < Math.abs(start[1] - botY) ? topY : botY;
+    return [
+      [start[0], start[1]],
+      [start[0], detourY],
+      [end[0], detourY],
+      [end[0], end[1]],
+    ];
+  }
+  const candidates: Point[] = [
+    [obstacle.x - m, obstacle.y - m],
+    [obstacle.x + obstacle.w + m, obstacle.y - m],
+    [obstacle.x - m, obstacle.y + obstacle.h + m],
+    [obstacle.x + obstacle.w + m, obstacle.y + obstacle.h + m],
+  ];
+  let best: { path: Point[]; length: number } | null = null;
+  for (const corner of candidates) {
+    if (segmentCrossesBBoxInterior(start, corner, obstacle)) continue;
+    if (segmentCrossesBBoxInterior(corner, end, obstacle)) continue;
+    const len =
+      Math.hypot(corner[0] - start[0], corner[1] - start[1]) +
+      Math.hypot(end[0] - corner[0], end[1] - corner[1]);
+    if (!best || len < best.length) {
+      best = {
+        path: [
+          [start[0], start[1]],
+          [corner[0], corner[1]],
+          [end[0], end[1]],
+        ],
+        length: len,
+      };
+    }
+  }
+  if (best) return best.path;
+  // Every corner is blocked (degenerate layout, e.g. endpoints flanking
+  // the obstacle on opposite sides). Fall back to a U-shape going over
+  // the top: this at least moves the polyline midpoint off the obstacle.
+  const topY = obstacle.y - m;
+  return [
+    [start[0], start[1]],
+    [start[0], topY],
+    [end[0], topY],
+    [end[0], end[1]],
+  ];
+}
+
 function buildRawPoints(
   start: Point,
   end: Point,
@@ -369,6 +540,21 @@ export function emitConnector(
     // above is exempted because ELK already spaces parallel edges itself.
     [start, end] = applyLaneOffset(rawStart, rawEnd, lane);
     rawPoints = buildRawPoints(start, end, routing, startDir);
+    // Sync-path obstacle detour. When an LLM stacks three nodes on the
+    // same axis (e.g. Web → Redis → DB in arch-cdn-03) and wires a
+    // straight Web→DB connector, the boundary-to-boundary line slices
+    // clean through the middle node's text. ELK would have routed around
+    // it, but the scene contains frames so buildGraphModel skipped ELK
+    // entirely. Detect the case here and insert a two-bend detour.
+    if (routing === 'straight' && p.routedPath === undefined) {
+      const excludeIds = new Set<PrimitiveId>();
+      if (typeof p.from === 'string') excludeIds.add(p.from);
+      if (typeof p.to === 'string') excludeIds.add(p.to);
+      const obstacle = findBlockingLabelBox(start, end, excludeIds, ctx);
+      if (obstacle) {
+        rawPoints = detourAroundObstacle(start, end, obstacle);
+      }
+    }
   }
   const { points, width, height } = normalizePoints(rawPoints);
 

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -511,3 +511,185 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     expect(arrow.endBinding).toBeNull();
   });
 });
+
+describe('emitConnector — straight-line obstacle detour (arch-cdn-03)', () => {
+  // Regression: arch-cdn-03 eval rendered a Web→DB "read" arrow as a single
+  // vertical straight line at x=250 from (250, 462.5) to (250, 652.5). A
+  // Redis Cache node sat between them at x=150-350, y=537.5-602.5, so the
+  // arrow — and its bound "read" label pinned to the polyline midpoint —
+  // rendered on top of the Redis node's text. The scene carried a Frame,
+  // so buildGraphModel returned null and ELK never had a chance to route
+  // the edge. The emit layer now detects the crossing and bends around.
+  it('vertical straight connector detours around a LabelBox sitting on the same axis', () => {
+    const web: LabelBox = {
+      kind: 'labelBox',
+      id: 'web' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 430],
+      fit: 'fixed',
+      size: [200, 65],
+      text: 'Web',
+    };
+    const redis: LabelBox = {
+      kind: 'labelBox',
+      id: 'redis' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 570],
+      fit: 'fixed',
+      size: [200, 65],
+      text: 'Redis',
+    };
+    const db: LabelBox = {
+      kind: 'labelBox',
+      id: 'db' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 710],
+      fit: 'fixed',
+      size: [200, 115],
+      text: 'DB',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'web' as PrimitiveId,
+      to: 'db' as PrimitiveId,
+      routing: 'straight',
+      label: 'read',
+    };
+    const result = compile(makeScene([web, redis, db, c]));
+    const arrow = findArrow(result.elements);
+    // Must bend: a 2-point straight line would cut through Redis.
+    expect(arrow.points.length).toBeGreaterThanOrEqual(4);
+    // None of the interior waypoints may sit inside Redis's bbox.
+    // Redis bbox: x=[150,350], y=[537.5, 602.5].
+    for (const [px, py] of arrow.points) {
+      const absX = arrow.x + px;
+      const absY = arrow.y + py;
+      const insideX = absX > 150 && absX < 350;
+      const insideY = absY > 537.5 && absY < 602.5;
+      expect(insideX && insideY).toBe(false);
+    }
+  });
+
+  it('does not detour when no obstacle sits on the straight line', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      routing: 'straight',
+    };
+    const result = compile(makeScene([a, b, c]));
+    const arrow = findArrow(result.elements);
+    // Untouched by the detour: still a simple 2-point straight line.
+    expect(arrow.points.length).toBe(2);
+  });
+
+  it('diagonal straight connector detours around a LabelBox its line crosses', () => {
+    // Regression: arch-cdn-03 re-run rendered "read" edges as diagonal
+    // lines from a Web Server node down to a DB Replica node, passing
+    // through a Redis Cache node placed in between but offset sideways.
+    // The axis-aligned detour missed these; the Liang-Barsky check catches
+    // any crossing regardless of orientation.
+    const web: LabelBox = {
+      kind: 'labelBox',
+      id: 'web' as PrimitiveId,
+      shape: 'rectangle',
+      at: [150, 480],
+      fit: 'fixed',
+      size: [160, 55],
+      text: 'Web',
+    };
+    const redis: LabelBox = {
+      kind: 'labelBox',
+      id: 'redis' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 620],
+      fit: 'fixed',
+      size: [180, 65],
+      text: 'Redis',
+    };
+    const db: LabelBox = {
+      kind: 'labelBox',
+      id: 'db' as PrimitiveId,
+      shape: 'rectangle',
+      at: [240, 780],
+      fit: 'fixed',
+      size: [180, 65],
+      text: 'DB',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'web' as PrimitiveId,
+      to: 'db' as PrimitiveId,
+      routing: 'straight',
+      label: 'read',
+    };
+    const result = compile(makeScene([web, redis, db, c]));
+    const arrow = findArrow(result.elements);
+    // Must bend around Redis.
+    expect(arrow.points.length).toBeGreaterThanOrEqual(3);
+    // No waypoint may sit strictly inside Redis.
+    // Redis bbox: x=[160, 340], y=[587.5, 652.5].
+    for (const [px, py] of arrow.points) {
+      const absX = arrow.x + px;
+      const absY = arrow.y + py;
+      const insideX = absX > 160 && absX < 340;
+      const insideY = absY > 587.5 && absY < 652.5;
+      expect(insideX && insideY).toBe(false);
+    }
+  });
+
+  it('endpoint-adjacent LabelBoxes (targets of other edges) do not trigger a false detour', () => {
+    // "cache" edge Web → Redis must stay straight even though Redis's
+    // bbox touches the arrow's end point. `findBlockingLabelBox` excludes
+    // the endpoint-owning primitives from the obstacle search.
+    const web: LabelBox = {
+      kind: 'labelBox',
+      id: 'web' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 430],
+      fit: 'fixed',
+      size: [200, 65],
+      text: 'Web',
+    };
+    const redis: LabelBox = {
+      kind: 'labelBox',
+      id: 'redis' as PrimitiveId,
+      shape: 'rectangle',
+      at: [250, 570],
+      fit: 'fixed',
+      size: [200, 65],
+      text: 'Redis',
+    };
+    const c: Connector = {
+      kind: 'connector',
+      id: 'c' as PrimitiveId,
+      from: 'web' as PrimitiveId,
+      to: 'redis' as PrimitiveId,
+      routing: 'straight',
+    };
+    const result = compile(makeScene([web, redis, c]));
+    const arrow = findArrow(result.elements);
+    expect(arrow.points.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- arch-cdn-03 eval: scenes with Frames skip buildGraphModel/ELK, so `emit/connector.ts` routed `routing:'straight'` as a 2-point line; when the LLM placed Redis Cache between Web Servers and DB Read Replica, the line and its bound \"read\" label both landed on top of the Redis node's text.
- Added a Liang-Barsky strict-interior crossing check against the registry's LabelBox bboxes (skipping endpoint-owning primitives), and a detour path builder that bends around the obstacle.
- Axis-aligned crossings take a 4-point L-L bypass on whichever side is closer to the source endpoint. Diagonals try each of the 4 inflated corner waypoints and pick the shortest L-path whose sub-segments both clear the obstacle.

## Eval impact

| | total | layout | readability | Redis overlap? |
|-|------|--------|-------------|----------------|
| before | 0.857 | 2 | 2 | yes |
| after s1 | 0.905 | 3 | 3 | no |
| after s2 | 0.857 | 3 | 3 | no |
| after s3 | 1.000 | 3 | 3 | no |

Remaining rubric complaints are semantic (\"write path goes from LB not from web server\"), not rendering overlap.

## Test plan

- [x] \`pnpm --filter @drawcast/core test\` (120/120 pass, includes 3 new detour regressions: vertical axis-aligned, diagonal, and endpoint-adjacent no-false-detour).
- [x] \`pnpm --filter @drawcast/core build && pnpm --filter @drawcast/mcp-server build\`
- [x] \`pnpm eval --id arch-cdn-03 --n 3\` — all pass, average 0.921 (baseline 0.857), no Redis-overlap complaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Straight-line connectors now intelligently route around label box obstacles, generating L-shaped or U-shaped detours to avoid intersections.

* **Tests**
  * Added test suite validating obstacle detection and detour behavior for vertical, diagonal, and adjacent obstacle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->