### PR TITLE
fix(core): nudge edge labels off non-endpoint LabelBoxes they overlap

### DIFF
--- a/evals/runner/metrics.ts
+++ b/evals/runner/metrics.ts
@@ -36,6 +36,7 @@ export function calculateMetrics(
       labels,
     ),
     overlap_pairs: countOverlaps(nodeElements),
+    edge_label_overlaps: countEdgeLabelOverlaps(elements, nodeElements),
   };
 
   if (question.expected.must_have_branch === true) {
@@ -89,6 +90,45 @@ function calculateConceptCoverage(
 
 function normalizeText(value: string): string {
   return value.toLocaleLowerCase().replace(/\s+/g, '');
+}
+
+function countEdgeLabelOverlaps(
+  allElements: readonly ExcalidrawElement[],
+  nodeElements: readonly ExcalidrawElement[],
+): number {
+  const shapeNodes = nodeElements.filter(
+    (element) => element.type !== 'text',
+  );
+  const arrowsById = new Map(
+    allElements.filter((el) => el.type === 'arrow').map((el) => [el.id, el]),
+  );
+  const edgeLabels = allElements.filter(
+    (el) =>
+      el.type === 'text' &&
+      typeof el.containerId === 'string' &&
+      arrowsById.has(el.containerId),
+  );
+  const nodeBoxesById = new Map(
+    shapeNodes.map((node) => [node.id, toBox(node)]),
+  );
+  let count = 0;
+  for (const label of edgeLabels) {
+    const lbox = toBox(label);
+    const arrow = arrowsById.get(label.containerId as string);
+    const endpointIds = new Set<string>();
+    const startId = arrow?.startBinding?.elementId;
+    const endId = arrow?.endBinding?.elementId;
+    if (typeof startId === 'string') endpointIds.add(startId);
+    if (typeof endId === 'string') endpointIds.add(endId);
+    // Endpoints are excluded — diamond/ellipse bboxes contain empty
+    // corners the label legitimately sits in, and labels flush against
+    // their own source/target are expected anchoring behaviour.
+    const hits = Array.from(nodeBoxesById).some(
+      ([id, nbox]) => !endpointIds.has(id) && intersects(lbox, nbox),
+    );
+    if (hits) count += 1;
+  }
+  return count;
 }
 
 function countOverlaps(elements: readonly ExcalidrawElement[]): number {

--- a/evals/runner/types.ts
+++ b/evals/runner/types.ts
@@ -86,6 +86,13 @@ export interface MetricsResult {
   edge_count_fit: 0 | 1;
   concept_coverage: number;
   overlap_pairs: number;
+  /**
+   * Count of edge-label text elements (text with `containerId` bound to an
+   * arrow) whose bounding box overlaps a node shape. A non-zero count means
+   * an edge label is rendered on top of a node body, which is a hard
+   * readability regression that the VLM rubric consistently penalises.
+   */
+  edge_label_overlaps: number;
   has_branch?: boolean;
   has_loop?: boolean;
 }

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -310,6 +310,111 @@ function findBlockingLabelBox(
   return null;
 }
 
+/** Gap the label keeps around any LabelBox after nudging. */
+const LABEL_NUDGE_GAP = 4;
+/** Cap on nudge iterations so we never loop on an unsolvable case. */
+const LABEL_NUDGE_MAX_ITER = 6;
+
+/**
+ * Axis-aligned bbox overlap. Uses strict `<` so boxes that share exactly an
+ * edge pixel don't count (matches `countOverlaps` in the eval metrics).
+ */
+function bboxOverlaps(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  b: ObstacleBBox,
+): boolean {
+  return x < b.x + b.w && x + w > b.x && y < b.y + b.h && y + h > b.y;
+}
+
+function findOverlappingLabelBox(
+  labelX: number,
+  labelY: number,
+  labelW: number,
+  labelH: number,
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): ObstacleBBox | null {
+  for (const [id, record] of ctx.registry) {
+    if (excludeIds.has(id)) continue;
+    if (record.kind !== 'labelBox') continue;
+    if (bboxOverlaps(labelX, labelY, labelW, labelH, record.bbox)) {
+      return record.bbox;
+    }
+  }
+  return null;
+}
+
+/**
+ * Slide the edge-label anchor along the tangent direction until the label's
+ * bbox no longer overlaps any non-endpoint LabelBox. Needed because the
+ * polyline midpoint can sit just inside a neighbour node when ELK packs
+ * nodes close together (arch-cdn-03: "읽기"/"쓰기" labels clipping the
+ * edge of the Redis Cache box). Returns the adjusted anchor centre, or
+ * the original if no clear position was found within the iteration cap.
+ */
+function nudgeLabelAwayFromNodes(
+  midX: number,
+  midY: number,
+  labelW: number,
+  labelH: number,
+  tangent: Point,
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): Point {
+  const tLen = Math.hypot(tangent[0], tangent[1]);
+  // Degenerate tangent (zero-length segment): give up — the label has no
+  // direction to slide along without leaving the edge altogether.
+  if (tLen < 1e-6) return [midX, midY];
+  const tx = tangent[0] / tLen;
+  const ty = tangent[1] / tLen;
+
+  let cx = midX;
+  let cy = midY;
+  for (let i = 0; i < LABEL_NUDGE_MAX_ITER; i += 1) {
+    const x = cx - labelW / 2;
+    const y = cy - labelH / 2;
+    const hit = findOverlappingLabelBox(x, y, labelW, labelH, excludeIds, ctx);
+    if (!hit) return [cx, cy];
+    // Slide away from the obstacle centre along the tangent. Projecting
+    // the "away" vector onto the tangent picks the side of the overlap
+    // that is closer to clear space along the edge.
+    const awayDx = cx - (hit.x + hit.w / 2);
+    const awayDy = cy - (hit.y + hit.h / 2);
+    const dir = awayDx * tx + awayDy * ty >= 0 ? 1 : -1;
+    // Distance needed to clear the obstacle along tangent — take the
+    // larger axis overlap so a single shift usually resolves.
+    const overlapX = Math.min(x + labelW - hit.x, hit.x + hit.w - x);
+    const overlapY = Math.min(y + labelH - hit.y, hit.y + hit.h - y);
+    const shift = Math.max(overlapX, overlapY, 1) + LABEL_NUDGE_GAP;
+    cx += tx * shift * dir;
+    cy += ty * shift * dir;
+  }
+  return [midX, midY];
+}
+
+/**
+ * Tangent vector at the label anchor, matching `computeLabelAnchor`'s
+ * segment choice so a nudge slides the label along the visible edge line.
+ */
+function tangentAtLabelAnchor(points: readonly Point[]): Point {
+  if (points.length < 2) return [1, 0];
+  if (points.length % 2 === 1) {
+    // Middle waypoint: average the incoming and outgoing directions so a
+    // corner kink gives a sensible glide direction.
+    const i = Math.floor(points.length / 2);
+    const prev = points[i - 1]!;
+    const next = points[i + 1]!;
+    return [next[0] - prev[0], next[1] - prev[1]];
+  }
+  const i = points.length / 2 - 1;
+  const a = points[i]!;
+  const b = points[i + 1]!;
+  return [b[0] - a[0], b[1] - a[1]];
+}
+
 /**
  * Build an L-shaped detour around `obstacle` going via the single corner
  * that lies on the far side of the obstacle relative to the straight line.
@@ -642,6 +747,25 @@ export function emitConnector(
       midX = mx + ux * axisShift;
       midY = my + uy * axisShift;
     }
+
+    // Shift the anchor along the edge tangent when the label bbox overlaps
+    // a neighbouring LabelBox. ELK can pack nodes close enough that the
+    // polyline midpoint lands ~2px inside an adjacent box (arch-cdn-03:
+    // "읽기"/"쓰기" labels clipping the Redis Cache corner). Endpoints
+    // are excluded so labels still rest flush against their own source
+    // and target boxes — that's expected behaviour for a bound label.
+    const labelExclude = new Set<PrimitiveId>();
+    if (typeof p.from === 'string') labelExclude.add(p.from);
+    if (typeof p.to === 'string') labelExclude.add(p.to);
+    [midX, midY] = nudgeLabelAwayFromNodes(
+      midX,
+      midY,
+      metrics.width,
+      metrics.height,
+      tangentAtLabelAnchor(rawPoints),
+      labelExclude,
+      ctx,
+    );
 
     const labelBase = baseElementFields({
       id: labelId,

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -692,4 +692,68 @@ describe('emitConnector — straight-line obstacle detour (arch-cdn-03)', () => 
     const arrow = findArrow(result.elements);
     expect(arrow.points.length).toBe(2);
   });
+
+  it('edge label is nudged along the edge tangent when it overlaps a neighbouring node', () => {
+    // Regression for arch-cdn-03: Web Server A → Read Replica A edge
+    // runs vertically past the Redis Cache A box. The polyline midpoint
+    // lands just inside the Redis box's right edge, so the "읽기" label
+    // clips the node corner. The nudge should slide the label along the
+    // tangent (vertical here) so the bbox no longer overlaps the
+    // neighbour, even though the neighbour is not an endpoint of the edge.
+    const source: LabelBox = {
+      kind: 'labelBox',
+      id: 'source' as PrimitiveId,
+      shape: 'rectangle',
+      at: [200, 100],
+      fit: 'fixed',
+      size: [200, 60],
+      text: 'Source',
+    };
+    const target: LabelBox = {
+      kind: 'labelBox',
+      id: 'target' as PrimitiveId,
+      shape: 'rectangle',
+      at: [200, 500],
+      fit: 'fixed',
+      size: [200, 60],
+      text: 'Target',
+    };
+    // Neighbour parked right where the edge midpoint would land (y=300).
+    const neighbour: LabelBox = {
+      kind: 'labelBox',
+      id: 'neighbour' as PrimitiveId,
+      shape: 'rectangle',
+      at: [110, 300],
+      fit: 'fixed',
+      size: [200, 80],
+      text: 'Neighbour',
+    };
+    const edge: Connector = {
+      kind: 'connector',
+      id: 'edge' as PrimitiveId,
+      from: 'source' as PrimitiveId,
+      to: 'target' as PrimitiveId,
+      label: '읽기',
+      routing: 'straight',
+    };
+    const result = compile(makeScene([source, target, neighbour, edge]));
+    const arrowLabel = result.elements.find(
+      (el) =>
+        el.type === 'text' &&
+        (el as { text?: string }).text === '읽기',
+    ) as { x: number; y: number; width: number; height: number } | undefined;
+    expect(arrowLabel).toBeDefined();
+    // Neighbour bbox is x∈[10,210], y∈[260,340]. The label bbox after the
+    // nudge must sit clear of that rectangle.
+    const lx1 = arrowLabel!.x;
+    const ly1 = arrowLabel!.y;
+    const lx2 = lx1 + arrowLabel!.width;
+    const ly2 = ly1 + arrowLabel!.height;
+    const nx1 = 10;
+    const ny1 = 260;
+    const nx2 = 210;
+    const ny2 = 340;
+    const overlaps = lx1 < nx2 && lx2 > nx1 && ly1 < ny2 && ly2 > ny1;
+    expect(overlaps).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Slide edge label anchors along the polyline tangent when the label bbox overlaps a non-endpoint LabelBox so ELK-packed scenes (arch-cdn-03 "읽기"/"쓰기" ↔ Redis Cache) stop clipping node corners.
- Add a deterministic `edge_label_overlaps` eval metric that excludes the edge's own source/target so diamond/ellipse endpoint bboxes don't produce false positives.

## Test plan
- [x] `pnpm --filter @drawcast/core test` — 122 tests pass, including new `edge label is nudged along the edge tangent when it overlaps a neighbouring node` regression.
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` → `edge_label_overlaps: 0`, diagram renders with no labels crossing node bodies.
- [x] `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --skip-rubric` → `edge_label_overlaps: 0`.
- [x] All suites (`pnpm -r test`): core 122/122, mcp-server 131/131, app 66/66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)