### PR TITLE
fix(core): collapse tiny ELK routedPath jogs into a single-bend L

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -236,6 +236,15 @@ function canonicaliseDirection(dx: number, dy: number): [number, number] {
 // the polyline midpoint) don't visually touch the bypassed node.
 const OBSTACLE_DETOUR_MARGIN = 20;
 
+// Perpendicular jog shorter than this is treated as a visual kink rather than
+// a meaningful bend. ELK routing sometimes stitches adjacent channels with a
+// few-pixel offset (e.g. flow-login-01 "재시도" edge: 9px horizontal between
+// two tall verticals) that reads as a double bend at the same corner; the VLM
+// rubric has flagged this specifically. 16px is safely below the smallest
+// single-character label height (~25px) so any real orthogonal segment that
+// separates labelled channels is preserved.
+const TINY_JOG_LENGTH = 16;
+
 interface ObstacleBBox {
   x: number;
   y: number;
@@ -506,6 +515,124 @@ function detourAroundObstacle(
   ];
 }
 
+type SegmentAxis = 'h' | 'v' | null;
+
+function segmentAxis(a: Point, b: Point): SegmentAxis {
+  const dx = Math.abs(a[0] - b[0]);
+  const dy = Math.abs(a[1] - b[1]);
+  if (dx < 1e-6 && dy > 1e-6) return 'v';
+  if (dy < 1e-6 && dx > 1e-6) return 'h';
+  return null;
+}
+
+function pathClearOfLabelBoxes(
+  points: readonly Point[],
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): boolean {
+  for (const [id, record] of ctx.registry) {
+    if (excludeIds.has(id)) continue;
+    if (record.kind !== 'labelBox') continue;
+    for (let i = 0; i < points.length - 1; i += 1) {
+      if (segmentCrossesBBoxInterior(points[i]!, points[i + 1]!, record.bbox)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Collapse three consecutive points P0-P1-P2 where P0→P1 and P1→P2 share the
+ * same direction (collinear and same sign). ELK routing never emits these on
+ * its own, but orthogonal-jog merging below can introduce them (shifting a
+ * short perpendicular step into the same line as a neighbouring segment).
+ * Endpoints are always preserved.
+ */
+function collapseCollinear(points: readonly Point[]): Point[] {
+  if (points.length < 3) return points.map((pt) => [pt[0], pt[1]] as Point);
+  const result: Point[] = [[points[0]![0], points[0]![1]]];
+  for (let i = 1; i < points.length - 1; i += 1) {
+    const prev = result[result.length - 1]!;
+    const curr = points[i]!;
+    const next = points[i + 1]!;
+    const d1x = curr[0] - prev[0];
+    const d1y = curr[1] - prev[1];
+    const d2x = next[0] - curr[0];
+    const d2y = next[1] - curr[1];
+    const cross = d1x * d2y - d1y * d2x;
+    const dot = d1x * d2x + d1y * d2y;
+    if (Math.abs(cross) < 1e-6 && dot > 0) continue;
+    result.push([curr[0], curr[1]]);
+  }
+  const last = points[points.length - 1]!;
+  result.push([last[0], last[1]]);
+  return result;
+}
+
+/**
+ * Merge tiny orthogonal jogs in an ELK-routed polyline. A jog is a 4-point
+ * window A-B-C-D where A→B and C→D are parallel (both horizontal or both
+ * vertical) and B→C is a perpendicular segment shorter than
+ * `TINY_JOG_LENGTH`. Visually this reads as a doubled kink at the same
+ * corner. We replace it with a single-bend L-shape via either A's column or
+ * D's column, picking whichever variant doesn't cross another node's bbox.
+ *
+ * Endpoints (index 0 and last) are preserved so bindings remain intact. On
+ * every successful merge we re-run collinear collapse because the neighbour
+ * segments often become colinear after the shift (the eval-hit case reduces
+ * from 6 points to 4 points in one pass).
+ */
+function mergeTinyJogs(
+  points: readonly Point[],
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): Point[] {
+  let current: Point[] = points.map((pt) => [pt[0], pt[1]] as Point);
+  let safetyCounter = current.length * 4;
+  for (;;) {
+    if (safetyCounter-- <= 0) break;
+    if (current.length < 4) break;
+    let mutated = false;
+    for (let i = 0; i <= current.length - 4; i += 1) {
+      const a = current[i]!;
+      const b = current[i + 1]!;
+      const c = current[i + 2]!;
+      const d = current[i + 3]!;
+      const ab = segmentAxis(a, b);
+      const bc = segmentAxis(b, c);
+      const cd = segmentAxis(c, d);
+      if (ab === null || bc === null || cd === null) continue;
+      if (ab !== cd) continue;
+      if (bc === ab) continue;
+      const jogLen = ab === 'v' ? Math.abs(c[0] - b[0]) : Math.abs(c[1] - b[1]);
+      if (jogLen >= TINY_JOG_LENGTH) continue;
+      const viaA: Point[] =
+        ab === 'v'
+          ? [a, [a[0], d[1]], d]
+          : [a, [d[0], a[1]], d];
+      const viaD: Point[] =
+        ab === 'v'
+          ? [a, [d[0], a[1]], d]
+          : [a, [a[0], d[1]], d];
+      let picked: Point[] | null = null;
+      if (pathClearOfLabelBoxes(viaA, excludeIds, ctx)) picked = viaA;
+      else if (pathClearOfLabelBoxes(viaD, excludeIds, ctx)) picked = viaD;
+      if (picked === null) continue;
+      current = [
+        ...current.slice(0, i),
+        ...picked.map((pt) => [pt[0], pt[1]] as Point),
+        ...current.slice(i + 4),
+      ];
+      current = collapseCollinear(current);
+      mutated = true;
+      break;
+    }
+    if (!mutated) break;
+  }
+  return current;
+}
+
 function buildRawPoints(
   start: Point,
   end: Point,
@@ -626,7 +753,15 @@ export function emitConnector(
     const last = p.routedPath[p.routedPath.length - 1]!;
     start = [first[0], first[1]];
     end = [last[0], last[1]];
-    rawPoints = p.routedPath.map((pt) => [pt[0], pt[1]] as Point);
+    const raw = p.routedPath.map((pt) => [pt[0], pt[1]] as Point);
+    // Collapse any collinear pairs ELK emitted as-is, then merge tiny
+    // perpendicular jogs that read as a doubled corner (flow-login-01
+    // "재시도" case). The obstacle check reuses the labelBox registry so
+    // we never shift a column onto another node's body.
+    const excludeIds = new Set<PrimitiveId>();
+    if (typeof p.from === 'string') excludeIds.add(p.from);
+    if (typeof p.to === 'string') excludeIds.add(p.to);
+    rawPoints = mergeTinyJogs(collapseCollinear(raw), excludeIds, ctx);
   } else {
     let startDir: PortDir | undefined;
     let rawStart: Point;

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -427,14 +427,14 @@ describe('emitConnector — boundary anchoring (B3)', () => {
   });
 
   it('routedPath label anchors on the middle segment, not the endpoint midpoint', () => {
-    // Regression for "재시도" / feedback-edge labels floating off-path. A
-    // 6-point ELK-routed feedback edge has endpoints far apart horizontally
-    // (~200px) but the actual drawn path runs as a narrow L along x≈9.
-    // The straight-line midpoint would land at x≈99 in open space; the
-    // real edge has no ink there and readers can't tell which arrow the
-    // label belongs to. Anchoring on the middle segment (matching
-    // Excalidraw 0.17.x's own bound-text logic) keeps the label on the
-    // segment that carries the edge.
+    // Regression for "재시도" / feedback-edge labels floating off-path.
+    // The ELK-routed feedback edge comes in as 6 points with a 9px
+    // horizontal jog between two parallel verticals; tiny-jog merging
+    // collapses it to a clean 4-point L ([84,526]→[84,239]→[281.83,239]
+    // →[281.83,229]) whose middle segment is the long horizontal at
+    // y=239. The label must land on that visible segment, NOT on the
+    // straight-line midpoint (182.9, 377.5) between the endpoints —
+    // which falls off every segment of the simplified path.
     const a: LabelBox = {
       kind: 'labelBox',
       id: 'a' as PrimitiveId,
@@ -485,11 +485,69 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     }
     const centerX = label.x + label.width / 2;
     const centerY = label.y + label.height / 2;
-    // Middle segment of the 6-point path is points[2]→points[3] = (93,476)→(93,239).
-    // Midpoint = (93, 357.5). The straight-line midpoint between waypoints[0]
-    // and waypoints[5] would be (182.9, 377.5) — off in open space.
-    expect(centerX).toBe(93);
-    expect(centerY).toBeCloseTo(357.5, 5);
+    // After tiny-jog merging the path is [[84,526], [84,239], [281.83,239],
+    // [281.83,229]]. The middle segment is points[1]→points[2] — a long
+    // horizontal at y=239, midpoint (182.915, 239). That IS on the visible
+    // edge; the straight-line endpoint midpoint (182.9, 377.5) is not.
+    expect(centerX).toBeCloseTo(182.915, 5);
+    expect(centerY).toBeCloseTo(239, 5);
+  });
+
+  it('collapses tiny ELK routedPath jogs into an L-shape', () => {
+    // Direct coverage for the flow-login-01 regression: a 6-point retry
+    // edge with a 9px horizontal jog at y=476 should emit as 4 points
+    // after simplification (one clean L via the left column). The path
+    // starts at the left edge of the source box and ends on the bottom
+    // of the target box; no obstacle sits on the shifted column so the
+    // via-A candidate is chosen.
+    const source: LabelBox = {
+      kind: 'labelBox',
+      id: 'src' as PrimitiveId,
+      shape: 'rectangle',
+      at: [140, 530],
+      fit: 'fixed',
+      size: [120, 40],
+      text: 'SRC',
+    };
+    const target: LabelBox = {
+      kind: 'labelBox',
+      id: 'tgt' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 200],
+      fit: 'fixed',
+      size: [240, 60],
+      text: 'TGT',
+    };
+    const retry: Connector = {
+      kind: 'connector',
+      id: 'retry' as PrimitiveId,
+      from: 'src' as PrimitiveId,
+      to: 'tgt' as PrimitiveId,
+      routing: 'elbow',
+      routedPath: [
+        [84, 526],
+        [84, 476],
+        [93, 476],
+        [93, 239],
+        [281.83, 239],
+        [281.83, 229],
+      ],
+    };
+    const result = compile(makeScene([source, target, retry]));
+    const arrow = result.elements.find(
+      (el): el is { type: 'arrow'; x: number; y: number; points: number[][] } =>
+        el.type === 'arrow',
+    );
+    if (arrow === undefined) throw new Error('expected arrow element');
+    // 4 points: start, one bend, horizontal landing, arrowhead.
+    expect(arrow.points).toHaveLength(4);
+    // Start and end preserved so the bindings still land on the bound shapes.
+    const absolute = arrow.points.map((pt) => [arrow.x + pt[0], arrow.y + pt[1]]);
+    expect(absolute[0]).toEqual([84, 526]);
+    expect(absolute[3]).toEqual([281.83, 229]);
+    // Intermediate corner picks A's column (x=84) because nothing blocks it.
+    expect(absolute[1]).toEqual([84, 239]);
+    expect(absolute[2]).toEqual([281.83, 239]);
   });
 
   it('raw Point endpoints are passed through unchanged (no boundary math)', () => {


### PR DESCRIPTION
## Summary
- ELK's orthogonal router occasionally emits a V-H-V (or H-V-H) window whose middle segment is only a few pixels long — a visible doubled kink at the same corner. The flow-login-01 "재시도" feedback edge hit this with a 9px horizontal jog between two tall verticals.
- Rubric reviewers specifically flagged it: "좌측 재시도 분기선의 꺾임이 많아 화살표 방향을 한 번 더 따라가게 된다."
- After loading `routedPath` in `emit/connector.ts`, merge any such window (middle segment < `TINY_JOG_LENGTH` = 16px) into a single-bend L via either endpoint's column, picking whichever variant stays clear of non-endpoint LabelBox interiors. Endpoints are preserved so bindings stay bound.
- The 6-point retry path from the eval baseline collapses to 4 points in one pass (a collinear-collapse follow-up catches the neighbour segments that align after the shift).

## Test plan
- [x] `pnpm --filter @drawcast/core test` — 123/123 passing, including a new regression test that asserts the 6-point retry input emits as 4 points with endpoints preserved and the bend chosen via the left column.
- [x] Re-ran `pnpm --filter drawcast-evals eval -- --id flow-login-01` — passes rubric; the "too many bends" minor issue from the prior run is no longer reported. Re-ran `flow-retry-05` — emitted retry arrow is a clean 2-point straight vertical.
- [x] Updated the existing `routedPath label anchors on the middle segment` test: the simplified 4-point path still anchors the "재시도" label on the visible middle segment, not on the straight-line endpoint midpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved ELK-routed connector rendering with simplified path segments and enhanced detection to prevent unwanted crossings with labels.

* **Tests**
  * Updated connector rendering tests to verify path simplification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->