### PR TITLE
fix(core): rebalance uneven V-H-V ELK elbows so labels sit mid-way

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -633,6 +633,74 @@ function mergeTinyJogs(
   return current;
 }
 
+/**
+ * Rebalance a V-H-V (or H-V-H) 4-point window whose two parallel legs are
+ * very uneven: specifically one parallel leg shorter than `TINY_JOG_LENGTH`
+ * while the middle perpendicular segment is long enough that
+ * `mergeTinyJogs` left the window intact. ELK sometimes pins the crossing
+ * to a near-source (or near-target) channel, which reads as a tiny stub at
+ * one end plus a long stub at the other — and because bound edge labels
+ * sit on the middle segment (`computeLabelAnchor`), the label ends up
+ * visually squished against the source (or target) node instead of between
+ * them (flow-login-01 "성공" branch: legs 10 / 182 / 135 → label at the
+ * 10px stub corner, right under the decision diamond).
+ *
+ * Shift B and C so the crossing runs along the midpoint of A and D on the
+ * parallel axis. Endpoints stay pinned. The shifted path must still clear
+ * every non-endpoint LabelBox; if not, leave the original shape alone so
+ * we don't trade a visual-balance fix for a node-crossing regression.
+ */
+function rebalanceUnevenElbow(
+  points: readonly Point[],
+  excludeIds: ReadonlySet<PrimitiveId>,
+  ctx: CompileContext,
+): Point[] {
+  if (points.length !== 4) return points.map((pt) => [pt[0], pt[1]] as Point);
+  const a = points[0]!;
+  const b = points[1]!;
+  const c = points[2]!;
+  const d = points[3]!;
+  const ab = segmentAxis(a, b);
+  const bc = segmentAxis(b, c);
+  const cd = segmentAxis(c, d);
+  if (ab === null || bc === null || cd === null) {
+    return points.map((pt) => [pt[0], pt[1]] as Point);
+  }
+  if (ab !== cd || bc === ab) {
+    return points.map((pt) => [pt[0], pt[1]] as Point);
+  }
+  const firstLen = ab === 'v' ? Math.abs(b[1] - a[1]) : Math.abs(b[0] - a[0]);
+  const lastLen = cd === 'v' ? Math.abs(d[1] - c[1]) : Math.abs(d[0] - c[0]);
+  const shortLen = Math.min(firstLen, lastLen);
+  const longLen = Math.max(firstLen, lastLen);
+  if (shortLen >= TINY_JOG_LENGTH) {
+    return points.map((pt) => [pt[0], pt[1]] as Point);
+  }
+  if (longLen < TINY_JOG_LENGTH * 2) {
+    return points.map((pt) => [pt[0], pt[1]] as Point);
+  }
+  const midpoint =
+    ab === 'v' ? (a[1] + d[1]) / 2 : (a[0] + d[0]) / 2;
+  const rebalanced: Point[] =
+    ab === 'v'
+      ? [
+          [a[0], a[1]],
+          [a[0], midpoint],
+          [d[0], midpoint],
+          [d[0], d[1]],
+        ]
+      : [
+          [a[0], a[1]],
+          [midpoint, a[1]],
+          [midpoint, d[1]],
+          [d[0], d[1]],
+        ];
+  if (!pathClearOfLabelBoxes(rebalanced, excludeIds, ctx)) {
+    return points.map((pt) => [pt[0], pt[1]] as Point);
+  }
+  return rebalanced;
+}
+
 function buildRawPoints(
   start: Point,
   end: Point,
@@ -761,7 +829,11 @@ export function emitConnector(
     const excludeIds = new Set<PrimitiveId>();
     if (typeof p.from === 'string') excludeIds.add(p.from);
     if (typeof p.to === 'string') excludeIds.add(p.to);
-    rawPoints = mergeTinyJogs(collapseCollinear(raw), excludeIds, ctx);
+    rawPoints = rebalanceUnevenElbow(
+      mergeTinyJogs(collapseCollinear(raw), excludeIds, ctx),
+      excludeIds,
+      ctx,
+    );
   } else {
     let startDir: PortDir | undefined;
     let rawStart: Point;

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -485,12 +485,14 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     }
     const centerX = label.x + label.width / 2;
     const centerY = label.y + label.height / 2;
-    // After tiny-jog merging the path is [[84,526], [84,239], [281.83,239],
-    // [281.83,229]]. The middle segment is points[1]→points[2] — a long
-    // horizontal at y=239, midpoint (182.915, 239). That IS on the visible
-    // edge; the straight-line endpoint midpoint (182.9, 377.5) is not.
+    // After tiny-jog merging the path would be [[84,526], [84,239],
+    // [281.83,239], [281.83,229]] — but the last V-leg is only 10px so
+    // the rebalance pass shifts the horizontal to the midpoint Y=377.5.
+    // The middle segment (points[1]→points[2]) is the horizontal at
+    // y=377.5, midpoint (182.915, 377.5). Both axes stay on the visible
+    // edge and the label sits midway between source and target.
     expect(centerX).toBeCloseTo(182.915, 5);
-    expect(centerY).toBeCloseTo(239, 5);
+    expect(centerY).toBeCloseTo(377.5, 5);
   });
 
   it('collapses tiny ELK routedPath jogs into an L-shape', () => {
@@ -545,9 +547,111 @@ describe('emitConnector — boundary anchoring (B3)', () => {
     const absolute = arrow.points.map((pt) => [arrow.x + pt[0], arrow.y + pt[1]]);
     expect(absolute[0]).toEqual([84, 526]);
     expect(absolute[3]).toEqual([281.83, 229]);
-    // Intermediate corner picks A's column (x=84) because nothing blocks it.
-    expect(absolute[1]).toEqual([84, 239]);
-    expect(absolute[2]).toEqual([281.83, 239]);
+    // Intermediate corners snap to A's column (x=84) / D's column (x=281.83).
+    // The Y of the horizontal is mid-way between source and target (not
+    // pinned to y=239 near the target) because tiny-jog merging left a
+    // 10px last-V-leg that the rebalance pass pulled to midY=377.5.
+    const midY = (526 + 229) / 2;
+    expect(absolute[1]).toEqual([84, midY]);
+    expect(absolute[2]).toEqual([281.83, midY]);
+  });
+
+  it('rebalances uneven V-H-V routedPath so the label sits between source and target', () => {
+    // flow-login-01 "성공" regression: ELK routes the success branch
+    // off the diamond's bottom-middle with a 10-182-135 leg split. The
+    // tiny first stub puts the horizontal (and its bound label) right
+    // under the decision node instead of midway toward the success box.
+    // The rebalance pass moves the horizontal to mid-Y so the two
+    // vertical legs become equal.
+    const diamond: LabelBox = {
+      kind: 'labelBox',
+      id: 'diamond' as PrimitiveId,
+      shape: 'diamond',
+      at: [235, 289],
+      fit: 'fixed',
+      size: [119, 92],
+      text: 'Q',
+    };
+    const success: LabelBox = {
+      kind: 'labelBox',
+      id: 'success' as PrimitiveId,
+      shape: 'rectangle',
+      at: [30, 526],
+      fit: 'fixed',
+      size: [160, 60],
+      text: 'OK',
+    };
+    const edge: Connector = {
+      kind: 'connector',
+      id: 'edge' as PrimitiveId,
+      from: 'diamond' as PrimitiveId,
+      to: 'success' as PrimitiveId,
+      routing: 'elbow',
+      routedPath: [
+        [295, 381],
+        [295, 391],
+        [110, 391],
+        [110, 526],
+      ],
+    };
+    const result = compile(makeScene([diamond, success, edge]));
+    const arrow = findArrow(result.elements);
+    expect(arrow.points).toHaveLength(4);
+    const absolute = arrow.points.map((pt) => [arrow.x + pt[0], arrow.y + pt[1]]);
+    // Endpoints preserved — bindings still land on their shapes.
+    expect(absolute[0]).toEqual([295, 381]);
+    expect(absolute[3]).toEqual([110, 526]);
+    // Crossing moved to the midpoint Y so the horizontal leg centres
+    // the bound label between source and target.
+    const midY = (381 + 526) / 2;
+    expect(absolute[1]).toEqual([295, midY]);
+    expect(absolute[2]).toEqual([110, midY]);
+  });
+
+  it('leaves a balanced V-H-V routedPath alone', () => {
+    // Guard against over-eager rebalancing: when ELK already produces a
+    // symmetric L-bend (both vertical legs longer than TINY_JOG_LENGTH)
+    // the output should pass through unchanged.
+    const source: LabelBox = {
+      kind: 'labelBox',
+      id: 'src' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const target: LabelBox = {
+      kind: 'labelBox',
+      id: 'tgt' as PrimitiveId,
+      shape: 'rectangle',
+      at: [300, 300],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const edge: Connector = {
+      kind: 'connector',
+      id: 'edge' as PrimitiveId,
+      from: 'src' as PrimitiveId,
+      to: 'tgt' as PrimitiveId,
+      routing: 'elbow',
+      routedPath: [
+        [140, 140],
+        [140, 220],
+        [340, 220],
+        [340, 300],
+      ],
+    };
+    const result = compile(makeScene([source, target, edge]));
+    const arrow = findArrow(result.elements);
+    const absolute = arrow.points.map((pt) => [arrow.x + pt[0], arrow.y + pt[1]]);
+    expect(absolute).toEqual([
+      [140, 140],
+      [140, 220],
+      [340, 220],
+      [340, 300],
+    ]);
   });
 
   it('raw Point endpoints are passed through unchanged (no boundary math)', () => {


### PR DESCRIPTION
## Summary
- ELK's routed V-H-V elbows sometimes pin the crossing a few pixels off one endpoint (flow-login-01 "성공"/"실패" branches came back with legs 10 / 182 / 135). The middle horizontal carries the bound edge label via `computeLabelAnchor`, so the label ended up squished right under the source node.
- `mergeTinyJogs` only collapses a tiny middle segment; it leaves a tiny first/last parallel leg alone. Add a companion `rebalanceUnevenElbow` post-pass: when one parallel leg is shorter than `TINY_JOG_LENGTH` and the other is ≥ 2×TINY_JOG_LENGTH, shift the crossing to the midpoint of the two endpoints along the parallel axis. Endpoints stay pinned, and any rebalance that would cross a non-endpoint LabelBox is rejected.
- Verified on flow-login-01: the "실패" arrow now routes 72.5 / 147.33 / 72.5 and its label sits centred between the decision diamond and the error node. Before/after PNGs in the eval runner confirm the visual fix.

## Test plan
- [x] `pnpm --filter @drawcast/core test` (125 tests, all pass — existing `mergeTinyJogs` tests updated so the follow-on rebalance expectation is pinned)
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` rendered PNG with balanced 실패 branch
- [x] `pnpm -r test` (all package suites green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)