### PR TITLE
fix(core): pad CJK edge-label bbox to prevent Excalidraw wrap

### DIFF
--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -15,7 +15,7 @@
 import type { Connector, Point, PrimitiveId, Radians } from '../primitives.js';
 import { baseElementFields } from '../utils/baseElementFields.js';
 import { newElementId } from '../utils/id.js';
-import { getLineHeight, measureText } from '../measure.js';
+import { containsCjk, getLineHeight, measureText } from '../measure.js';
 import type {
   ExcalidrawArrowElement,
   ExcalidrawTextElement,
@@ -921,6 +921,20 @@ export function emitConnector(
     const fontSize = style.fontSize ?? ctx.theme.defaultFontSize;
     const lineHeight = getLineHeight(fontFamily);
     const metrics = measureText({ text: p.label, fontSize, fontFamily });
+    // Widen the bound-label bbox for CJK text. Our static `measureText`
+    // lands on exactly the runtime pixel width for Latin glyphs, but the
+    // default Excalidraw fonts (Excalifont / Virgil / Cascadia) ship no
+    // Hangul / Kana glyphs — the renderer falls back to the platform
+    // font, which measures slightly wider per glyph. A tight bbox makes
+    // `refreshTextDimensions` wrap a 3-char Korean label into three
+    // single-character lines that then render as a vertical stack
+    // (flow-login-01 "재시도" case). An `fontSize * 0.3` safety margin
+    // covers the measured fallback overshoot without noticeably shifting
+    // the label's visual centre.
+    const cjkWidthBuffer = containsCjk(p.label)
+      ? Math.ceil(fontSize * 0.3)
+      : 0;
+    const labelWidth = metrics.width + cjkWidthBuffer;
     // Anchor on the polyline, not the straight line between endpoints.
     // For orthogonally routed feedback edges (ELK `routedPath`, or the
     // built-in elbow router) the straight-line midpoint can fall far off
@@ -967,7 +981,7 @@ export function emitConnector(
     [midX, midY] = nudgeLabelAwayFromNodes(
       midX,
       midY,
-      metrics.width,
+      labelWidth,
       metrics.height,
       tangentAtLabelAnchor(rawPoints),
       labelExclude,
@@ -976,9 +990,9 @@ export function emitConnector(
 
     const labelBase = baseElementFields({
       id: labelId,
-      x: midX - metrics.width / 2,
+      x: midX - labelWidth / 2,
       y: midY - metrics.height / 2,
-      width: metrics.width,
+      width: labelWidth,
       height: metrics.height,
       angle: 0 as Radians,
       // Edge labels always render in a high-contrast dark color, not the

--- a/packages/core/src/measure.ts
+++ b/packages/core/src/measure.ts
@@ -42,6 +42,21 @@ function isCjkCodePoint(cp: number): boolean {
 }
 
 /**
+ * Does `text` contain any CJK / fullwidth codepoint? Callers use this to
+ * apply a wider bbox buffer when Excalidraw's runtime font fallback (the
+ * default Excalifont / Virgil / Cascadia families ship no Hangul / Kana
+ * glyphs, so the renderer falls back to the platform font) measures wider
+ * than our static `avgCharWidth` estimate.
+ */
+export function containsCjk(text: string): boolean {
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (isCjkCodePoint(cp)) return true;
+  }
+  return false;
+}
+
+/**
  * Compute visual width units for a line: CJK/fullwidth counts as 2,
  * everything else as 1. Iteration is codepoint-aware so surrogate pairs
  * don't double-count.

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -918,4 +918,63 @@ describe('emitConnector — straight-line obstacle detour (arch-cdn-03)', () => 
     const overlaps = lx1 < nx2 && lx2 > nx1 && ly1 < ny2 && ly2 > ny1;
     expect(overlaps).toBe(false);
   });
+
+  it('CJK bound label bbox carries a width buffer so Excalidraw does not wrap it', () => {
+    // flow-login-01 "재시도": the default Excalidraw fonts ship no Hangul
+    // glyphs, so Excalidraw's runtime `refreshTextDimensions` measures
+    // the label slightly wider than our static `measureText` estimate.
+    // With a flush bbox the runtime wraps the 3-char label into three
+    // single-character lines that render as a vertically-stacked column.
+    // The emitter must pad the CJK label bbox so the runtime never
+    // wraps. Latin labels of matching codepoint count stay flush because
+    // their glyphs render in the authored Excalidraw font.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [120, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 300],
+      fit: 'fixed',
+      size: [120, 40],
+      text: 'B',
+    };
+    const korean: Connector = {
+      kind: 'connector',
+      id: 'c-kor' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      label: '재시도',
+    };
+    const latin: Connector = {
+      kind: 'connector',
+      id: 'c-lat' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      label: 'RET',
+    };
+    const korResult = compile(makeScene([a, b, korean]));
+    const latResult = compile(makeScene([a, b, latin]));
+    const korLabel = korResult.elements.find(
+      (el) => el.type === 'text' && (el as { text?: string }).text === '재시도',
+    ) as { width: number } | undefined;
+    const latLabel = latResult.elements.find(
+      (el) => el.type === 'text' && (el as { text?: string }).text === 'RET',
+    ) as { width: number } | undefined;
+    expect(korLabel).toBeDefined();
+    expect(latLabel).toBeDefined();
+    // "재시도" measures as 3 CJK chars × 2 visual units × 0.55 × 20 = 66px.
+    // The CJK padding must round up to at least 6px so the bbox clears the
+    // runtime overshoot; anything smaller risks the single-character wrap.
+    expect(korLabel!.width).toBeGreaterThanOrEqual(66 + 6);
+    // Latin labels stay tight against `measureText` (no fallback overshoot).
+    expect(latLabel!.width).toBeLessThan(66);
+  });
 });


### PR DESCRIPTION
## Summary
- 기본 Excalidraw 폰트(Excalifont/Virgil/Cascadia)는 한글·카나 글리프를 포함하지 않아 런타임에서 플랫폼 폰트로 폴백한다. 그 폴백 폰트는 우리의 정적 `measureText` 추정보다 살짝 더 넓게 측정되어, 플러시한 bbox일 때 `refreshTextDimensions`가 3글자 라벨("재시도")을 세 줄로 감싸 세로로 쌓인 텍스트로 렌더된다.
- 에지 라벨 bbox에 CJK 문자가 포함된 경우에만 `fontSize * 0.3` 너비 버퍼를 추가해 런타임 래핑을 방지. 라틴 라벨은 기존 동작 유지.
- 재발 방지 테스트 추가.

## Evidence
E2E `pnpm --filter drawcast-evals eval -- --id flow-login-01 --skip-rubric` 실행 결과:

**Before (run `2026-04-22T01-02-29Z`)**: "재시도" 라벨이 피드백 엣지의 수직 구간에서 1글자씩 줄바꿈되어 `재 / 시 / 도` 세로 스택으로 렌더.

**After (run `2026-04-22T01-12-51Z`)**: 모든 한국어 에지 라벨(`재시도`, `재입력`, `성공`, `실패` 등)이 수평으로 한 줄 렌더. `"재시도"` 라벨 width가 66 → 72로 증가(6px 버퍼).

## Test plan
- [x] `pnpm --filter '@drawcast/core' test` — 126/126
- [x] `pnpm --filter '@drawcast/mcp-server' test` — 131/131
- [x] `pnpm --filter '@drawcast/app' test` — 66/66
- [x] E2E `flow-login-01` 재실행 후 PNG 육안 검증
- [x] 신규 회귀 테스트: CJK 라벨은 `measureText.width + 6` 이상, 라틴 라벨은 tight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of connector labels containing CJK (Chinese, Japanese, Korean) characters by applying proper width adjustment to prevent unintended text wrapping.

* **Tests**
  * Added regression test to verify connector label sizing for CJK characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->