### PR TITLE
fix(core): shift crowded H-V-H arrows so bound labels clear sibling polylines

### DIFF
--- a/packages/core/src/compile/passes.ts
+++ b/packages/core/src/compile/passes.ts
@@ -7,7 +7,11 @@ import type { Connector, PrimitiveId, Scene } from '../primitives.js';
 import type { CompileContext } from './context.js';
 import { emitLabelBox } from '../emit/labelBox.js';
 import { emitSticky } from '../emit/sticky.js';
-import { emitConnector, type ConnectorLane } from '../emit/connector.js';
+import {
+  clearEdgeLabelsFromOtherArrows,
+  emitConnector,
+  type ConnectorLane,
+} from '../emit/connector.js';
 import { applyGroup } from '../emit/group.js';
 import { emitFrame, applyFrameChildren } from '../emit/frame.js';
 import { emitLine } from '../emit/line.js';
@@ -74,6 +78,13 @@ export function passRelational(scene: Scene, ctx: CompileContext): void {
   for (const p of connectors) {
     emitConnector(p, ctx, lanes.get(p.id));
   }
+
+  // After every arrow + bound label is emitted, sweep for labels that
+  // landed on a non-own arrow's polyline and shift the owning arrow's
+  // middle segment perpendicular so the anchored label clears. Runs here
+  // (not per-connector) so the sweep sees the full final arrow set rather
+  // than only the prefix emitted before this connector.
+  clearEdgeLabelsFromOtherArrows(ctx);
 }
 
 function assignConnectorLanes(

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -1038,3 +1038,168 @@ export function emitConnector(
     bbox: { x: start[0], y: start[1], w: width, h: height },
   });
 }
+
+/**
+ * Perpendicular offsets (in px) tried when shifting a crowded middle segment
+ * so the anchored label clears neighbouring edges. Ordered small-first so the
+ * visible polyline change is minimised.
+ */
+const MIDDLE_SEGMENT_SHIFTS = [30, -30, 50, -50, 80, -80] as const;
+
+/**
+ * Walk every emitted bound edge label and, when its bbox lands on a non-own
+ * arrow's polyline segment, shift the OWN arrow's middle segment
+ * perpendicular until the label clears. Targets 4-point orthogonal routes
+ * (H-V-H or V-H-V) produced by ELK for converging feedback fans — e.g. the
+ * `flow-ci-04` CI pipeline, where five "실패" edges share a narrow vertical
+ * corridor and the labels stack on top of adjacent vertical stems.
+ *
+ * Why a post-pass: bound-text positions are recomputed by Excalidraw at
+ * render time from the arrow's middle-segment midpoint (`getBoundTextElement
+ * Position`), so moving the text element itself has no effect — the fix has
+ * to move the *arrow*. The per-connector emit can only see previously
+ * emitted arrows, so the final global view lives here.
+ *
+ * Conservative by design: rolls back if no shift clears, refuses shifts that
+ * would push a leg through a non-endpoint LabelBox, and only touches
+ * polylines whose shape matches the known regression.
+ */
+export function clearEdgeLabelsFromOtherArrows(ctx: CompileContext): void {
+  const arrows: ExcalidrawArrowElement[] = [];
+  for (const e of ctx.elements) {
+    if (e.type === 'arrow') arrows.push(e as ExcalidrawArrowElement);
+  }
+  if (arrows.length < 2) return;
+
+  const textByArrow = new Map<string, ExcalidrawTextElement>();
+  for (const e of ctx.elements) {
+    if (e.type !== 'text') continue;
+    const t = e as ExcalidrawTextElement;
+    if (typeof t.containerId === 'string') {
+      textByArrow.set(t.containerId, t);
+    }
+  }
+
+  function absPts(arrow: ExcalidrawArrowElement): Point[] {
+    return arrow.points.map(
+      ([px, py]) => [arrow.x + px, arrow.y + py] as Point,
+    );
+  }
+
+  function labelBbox(
+    arrow: ExcalidrawArrowElement,
+    text: ExcalidrawTextElement,
+  ): ObstacleBBox {
+    const pts = absPts(arrow);
+    const [cx, cy] = computeLabelAnchor(pts);
+    return {
+      x: cx - text.width / 2,
+      y: cy - text.height / 2,
+      w: text.width,
+      h: text.height,
+    };
+  }
+
+  function anyOtherArrowCrossesBox(
+    ownId: string,
+    box: ObstacleBBox,
+  ): boolean {
+    for (const other of arrows) {
+      if (other.id === ownId) continue;
+      const opts = absPts(other);
+      for (let i = 0; i < opts.length - 1; i += 1) {
+        if (segmentCrossesBBoxInterior(opts[i]!, opts[i + 1]!, box)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  function endpointPrimitiveIds(
+    arrow: ExcalidrawArrowElement,
+  ): Set<PrimitiveId> {
+    const excludeIds = new Set<PrimitiveId>();
+    const startElemId = arrow.startBinding?.elementId;
+    const endElemId = arrow.endBinding?.elementId;
+    for (const [primId, rec] of ctx.registry) {
+      if (rec.kind !== 'labelBox') continue;
+      if (
+        (startElemId !== undefined && rec.elementIds.includes(startElemId)) ||
+        (endElemId !== undefined && rec.elementIds.includes(endElemId))
+      ) {
+        excludeIds.add(primId);
+      }
+    }
+    return excludeIds;
+  }
+
+  for (const arrow of arrows) {
+    const text = textByArrow.get(arrow.id);
+    if (!text) continue;
+    if (arrow.points.length !== 4) continue;
+    const p0 = arrow.points[0]!;
+    const p1 = arrow.points[1]!;
+    const p2 = arrow.points[2]!;
+    const p3 = arrow.points[3]!;
+    const ax01 = segmentAxis(p0 as Point, p1 as Point);
+    const ax12 = segmentAxis(p1 as Point, p2 as Point);
+    const ax23 = segmentAxis(p2 as Point, p3 as Point);
+    if (ax01 === null || ax12 === null || ax23 === null) continue;
+    if (ax01 !== ax23 || ax12 === ax01) continue;
+
+    if (!anyOtherArrowCrossesBox(arrow.id, labelBbox(arrow, text))) continue;
+
+    const excludePrims = endpointPrimitiveIds(arrow);
+    const orig1: Point = [p1[0], p1[1]];
+    const orig2: Point = [p2[0], p2[1]];
+    let resolved = false;
+
+    for (const shift of MIDDLE_SEGMENT_SHIFTS) {
+      if (ax12 === 'v') {
+        arrow.points[1] = [orig1[0] + shift, orig1[1]] as typeof arrow.points[0];
+        arrow.points[2] = [orig2[0] + shift, orig2[1]] as typeof arrow.points[0];
+      } else {
+        arrow.points[1] = [orig1[0], orig1[1] + shift] as typeof arrow.points[0];
+        arrow.points[2] = [orig2[0], orig2[1] + shift] as typeof arrow.points[0];
+      }
+
+      const shiftedAbs = absPts(arrow);
+      const crossesNode =
+        !pathClearOfLabelBoxes(shiftedAbs, excludePrims, ctx);
+      if (crossesNode) continue;
+
+      if (!anyOtherArrowCrossesBox(arrow.id, labelBbox(arrow, text))) {
+        updateArrowExtents(arrow);
+        resolved = true;
+        break;
+      }
+    }
+
+    if (!resolved) {
+      arrow.points[1] = orig1 as typeof arrow.points[0];
+      arrow.points[2] = orig2 as typeof arrow.points[0];
+    }
+  }
+}
+
+/**
+ * Recompute `width` / `height` from the current local-point list. `x` / `y`
+ * stay fixed because `points[0]` remains `[0,0]` (P3); only the spanned bbox
+ * can change when an interior point is nudged perpendicular.
+ */
+function updateArrowExtents(arrow: ExcalidrawArrowElement): void {
+  if (arrow.points.length === 0) return;
+  let minX = arrow.points[0]![0];
+  let maxX = minX;
+  let minY = arrow.points[0]![1];
+  let maxY = minY;
+  for (const [px, py] of arrow.points) {
+    if (px < minX) minX = px;
+    if (px > maxX) maxX = px;
+    if (py < minY) minY = py;
+    if (py > maxY) maxY = py;
+  }
+  arrow.width = maxX - minX;
+  arrow.height = maxY - minY;
+}

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -978,3 +978,170 @@ describe('emitConnector — straight-line obstacle detour (arch-cdn-03)', () => 
     expect(latLabel!.width).toBeLessThan(66);
   });
 });
+
+describe('passRelational — clearEdgeLabelsFromOtherArrows post-pass', () => {
+  // flow-ci-04 regression: multiple "실패" edges share a narrow vertical
+  // corridor and a main-flow vertical arrow stems through where their bound
+  // labels anchor (the middle-segment midpoint of each H-V-H feedback
+  // polyline). Excalidraw recomputes bound-text positions from the arrow
+  // polyline at render time, so the fix has to move the *arrow* — the
+  // post-pass shifts the 4-point arrow's middle segment perpendicular until
+  // the label bbox clears every non-own polyline.
+  //
+  // Geometry for this test:
+  //   A (100,100..180,140) — right-centre (180, 120)
+  //   B (400,260..480,300) — left-centre  (400, 280)
+  //   C (240, 20..320, 60) — bottom-centre (280,  60)
+  //   D (240,340..320,380) — top-centre   (280, 380)
+  //   E1 A→B H-V-H via X=280 with label "L"; label anchor = (280, 200)
+  //   E2 C→D vertical at X=280
+  // The vertical polyline of E2 passes straight through E1's bound-label
+  // bbox, so the post-pass must shift E1's middle segment in X.
+  it('shifts a 4-point H-V-H arrow whose bound label sits on another arrow', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [400, 260],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const c: LabelBox = {
+      kind: 'labelBox',
+      id: 'c' as PrimitiveId,
+      shape: 'rectangle',
+      at: [240, 20],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'C',
+    };
+    const d: LabelBox = {
+      kind: 'labelBox',
+      id: 'd' as PrimitiveId,
+      shape: 'rectangle',
+      at: [240, 340],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'D',
+    };
+    const e1: Connector = {
+      kind: 'connector',
+      id: 'e1' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      label: 'L',
+      routing: 'elbow',
+      routedPath: [
+        [180, 120],
+        [280, 120],
+        [280, 280],
+        [400, 280],
+      ],
+    };
+    const e2: Connector = {
+      kind: 'connector',
+      id: 'e2' as PrimitiveId,
+      from: 'c' as PrimitiveId,
+      to: 'd' as PrimitiveId,
+      routing: 'elbow',
+      routedPath: [
+        [280, 60],
+        [280, 340],
+      ],
+    };
+
+    const result = compile(makeScene([a, b, c, d, e1, e2]));
+    const arrows = result.elements.filter(
+      (el): el is ExcalidrawArrowElement => el.type === 'arrow',
+    );
+    const e1Arrow = arrows.find(
+      (ar) => ar.boundElements?.some((be) => be.type === 'text'),
+    );
+    if (e1Arrow === undefined) throw new Error('expected labelled arrow');
+
+    expect(e1Arrow.points).toHaveLength(4);
+    const abs = e1Arrow.points.map(
+      (pt) => [e1Arrow.x + pt[0], e1Arrow.y + pt[1]] as [number, number],
+    );
+    // Endpoints still anchored to A's right edge and B's left edge.
+    expect(abs[0]).toEqual([180, 120]);
+    expect(abs[3]).toEqual([400, 280]);
+    // Middle segment was shifted OFF the crowded X=280 corridor — the
+    // smallest candidate shift (±30) already clears the E2 polyline, so the
+    // new vertical lives at X=310 (the rollback would leave it at 280).
+    expect(abs[1]![0]).not.toBe(280);
+    expect(abs[2]![0]).not.toBe(280);
+    expect(abs[1]![0]).toBe(abs[2]![0]);
+    expect(abs[1]![1]).toBe(120);
+    expect(abs[2]![1]).toBe(280);
+
+    // Excalidraw recomputes the bound-label position at render time from the
+    // arrow polyline's middle-segment midpoint, so what actually clears the
+    // E2 corridor is the SHIFTED middle-segment X — checked above. (The
+    // text element's stored x/y remain at the pre-shift emit position,
+    // because only the arrow has to move for the runtime anchor to shift.)
+    const newMidX = (abs[1]![0] + abs[2]![0]) / 2;
+    expect(Math.abs(newMidX - 280)).toBeGreaterThanOrEqual(30);
+  });
+
+  it('leaves a 4-point arrow alone when its label is not crossed by any other arrow', () => {
+    // Guard: the post-pass must only fire on confirmed overlaps. A solo
+    // H-V-H connector whose label bbox is clear of every sibling polyline
+    // should pass through untouched so that routine compiles do not acquire
+    // spurious perpendicular nudges.
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 100],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      at: [400, 260],
+      fit: 'fixed',
+      size: [80, 40],
+      text: 'B',
+    };
+    const e1: Connector = {
+      kind: 'connector',
+      id: 'e1' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+      label: 'L',
+      routing: 'elbow',
+      routedPath: [
+        [180, 120],
+        [280, 120],
+        [280, 280],
+        [400, 280],
+      ],
+    };
+
+    const result = compile(makeScene([a, b, e1]));
+    const arrow = findArrow(result.elements);
+    const abs = arrow.points.map(
+      (pt) => [arrow.x + pt[0], arrow.y + pt[1]] as [number, number],
+    );
+    expect(abs).toEqual([
+      [180, 120],
+      [280, 120],
+      [280, 280],
+      [400, 280],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `clearEdgeLabelsFromOtherArrows` post-pass in `passRelational` that nudges 4-point H-V-H / V-H-V arrow polylines perpendicular when the bound label bbox lands on a non-own arrow's segment.
- Excalidraw 0.17.x recomputes bound-text positions from the arrow polyline at render time (`getBoundTextElementPosition`), so moving the text element is a no-op — the fix has to move the arrow itself.
- Covers the `flow-ci-04` regression where five parallel "실패" feedback edges share a narrow vertical corridor with a main-flow vertical arrow.

## Implementation notes
- Shift candidates: ±30, ±50, ±80 px (smallest first to minimise the visible polyline change).
- Each candidate is rejected if it would push a leg through a non-endpoint LabelBox; if no candidate clears, the arrow rolls back to its original geometry.
- Post-pass runs once after all connectors are emitted so every sibling polyline is visible (per-connector emit only sees the prefix).

## Test plan
- [x] `pnpm --filter @drawcast/core test` — 128 tests pass (126 existing + 2 new in `emit-connector.test.ts` covering the crowded-crossing shift and the no-op guard).
- [x] `pnpm --filter @drawcast/core build` (tsc) clean.
- [x] `pnpm lint` clean across workspaces.
- [x] `pnpm eval -- --id flow-ci-04 --n 1` pass_rate=1 on the post-fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)