### PR TITLE
fix(core): skip ELK layout for hand-laid-out scenes with rail-shaped lifelines

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -1,0 +1,1 @@
+{"run_id":"20260422-050211-8678","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-22T05:21:00Z"}

--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -25,6 +25,13 @@ const MIN_LAYOUT_WIDTH = 80;
 const MIN_LAYOUT_HEIGHT = 40;
 const FIXED_FALLBACK_WIDTH = 150;
 const FIXED_FALLBACK_HEIGHT = 60;
+// A LabelBox whose narrower side is ≤ this threshold is a "rail" shape
+// (sequence-diagram lifeline, swimlane divider) rather than a content
+// node. See `hasRailShapedLabelBox` for why these short-circuit the
+// graph build. Content nodes are ≥ MIN_LAYOUT_HEIGHT (40) in practice,
+// and seq-oauth-01 lifelines are 4px wide — a 10px threshold leaves a
+// wide safety margin on both sides.
+const RAIL_MIN_SIDE_THRESHOLD = 10;
 // Ellipse/diamond bounding boxes must be larger than their inscribed
 // rectangle, otherwise the emit layer's `maxTextWidth = width - 2*padding`
 // clamps wrap to fewer lines than ELK reserved vertical space for and
@@ -49,6 +56,21 @@ export function buildGraphModel(
   const primitives = [...scene.primitives.values()];
 
   if (skipIfFrame && primitives.some((p) => p.kind === 'frame')) {
+    return null;
+  }
+
+  // A rail-shaped LabelBox (sequence-diagram lifeline, swimlane divider)
+  // signals the scene is hand-laid-out along an axis that ELK's layered
+  // algorithm does not model. Passing it through anyway makes layered
+  // treat the rail as an ordinary node and rebuild columns around it:
+  // seq-oauth-01 baseline placed four participant headers at y=0 with
+  // 1220-tall lifelines at y=70, and ELK promoted the lifelines to their
+  // own layers and stacked every header at y≈592 (the lifeline midline),
+  // leaving messages dangling above and below the participant row.
+  // Fall back to the sync compile path so the declared `at` coordinates
+  // survive — this matches the existing "Frame present → skip ELK"
+  // escape hatch for the same reason (out-of-scope compound layout).
+  if (primitives.some(hasRailShapedLabelBox)) {
     return null;
   }
 
@@ -77,6 +99,13 @@ export function buildGraphModel(
     children: nodes,
     edges,
   };
+}
+
+function hasRailShapedLabelBox(primitive: Primitive): boolean {
+  if (primitive.kind !== 'labelBox') return false;
+  if (primitive.size === undefined) return false;
+  const [width, height] = primitive.size;
+  return Math.min(width, height) <= RAIL_MIN_SIDE_THRESHOLD;
 }
 
 function labelBoxToNode(

--- a/packages/core/test/buildGraphModel.test.ts
+++ b/packages/core/test/buildGraphModel.test.ts
@@ -203,4 +203,56 @@ describe('buildGraphModel — labelBox size measurement', () => {
     expect(n.fixedPosition!.x).toBe(500 - n.width! / 2);
     expect(n.fixedPosition!.y).toBe(300 - n.height! / 2);
   });
+
+  // Regression guard for seq-oauth-01 eval: Claude emitted a sequence
+  // diagram with 4 participant headers and 4 tall/thin lifeline boxes
+  // (size [4, 1220]). ELK's layered algorithm then promoted those
+  // lifelines to their own columns and stacked the participant headers
+  // at the lifelines' vertical midpoint, destroying the "actors on top
+  // / messages below" structure. Rail-shaped LabelBoxes now short-
+  // circuit graph building so the sync compile path preserves `at`.
+  it('returns null when the scene contains a rail-shaped LabelBox (lifeline / divider)', () => {
+    const header: LabelBox = {
+      kind: 'labelBox',
+      id: 'user_hdr' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      at: [50, 0],
+      text: '사용자',
+    };
+    const lifeline: LabelBox = {
+      kind: 'labelBox',
+      id: 'user_life' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [4, 1220],
+      at: [118, 70],
+      text: '',
+    };
+    const graph = buildGraphModel(makeScene([header, lifeline]));
+    expect(graph).toBeNull();
+  });
+
+  it('keeps normal-shape scenes in scope (no rail → non-null graph)', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      text: 'B',
+    };
+    const graph = buildGraphModel(makeScene([a, b]));
+    expect(graph).not.toBeNull();
+    expect(graph!.children).toHaveLength(2);
+  });
 });

--- a/packages/core/test/compileAsync.test.ts
+++ b/packages/core/test/compileAsync.test.ts
@@ -131,6 +131,45 @@ describe('compileAsync', () => {
     expect(firstCoords).toEqual(secondCoords);
   });
 
+  // Regression guard for seq-oauth-01 eval: when the LLM emits a
+  // sequence diagram with narrow lifeline LabelBoxes, the scene is
+  // hand-laid-out and ELK must not touch it. Without this skip the
+  // layered algorithm treated lifelines as ordinary nodes and stacked
+  // the participant headers at the lifeline midline, destroying the
+  // actors-on-top structure.
+  it('skips layout when the scene contains a rail-shaped lifeline LabelBox', async () => {
+    const header: LabelBox = {
+      kind: 'labelBox',
+      id: 'actor_hdr' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      at: [50, 0],
+      text: '사용자',
+    };
+    const lifeline: LabelBox = {
+      kind: 'labelBox',
+      id: 'actor_life' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [4, 1220],
+      at: [118, 70],
+      text: '',
+    };
+    const scene = makeScene([header, lifeline]);
+    const sync = compile(scene);
+    const async = await compileAsync(scene, { useLayout: true });
+    const syncRectXs = sync.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((el) => el.x)
+      .sort((a, b) => a - b);
+    const asyncRectXs = async.elements
+      .filter((el): el is ExcalidrawRectangleElement => el.type === 'rectangle')
+      .map((el) => el.x)
+      .sort((a, b) => a - b);
+    expect(asyncRectXs).toEqual(syncRectXs);
+  });
+
   it('skips layout when the scene contains a frame (Phase 2 scope)', async () => {
     const frame: Frame = {
       kind: 'frame',


### PR DESCRIPTION
## Summary

- Automation loop run `20260422-050211-8678` picked `seq-oauth-01` (category `sequence`, difficulty `medium`). The baseline PNG failed rubric 0.476 with `layout=1`, `readability=1`: ELK's layered algorithm re-laid the LLM-emitted sequence diagram so participant headers ended up in the middle of the canvas with messages floating above and below.
- Root cause: `buildGraphModel` forwards every `LabelBox` — including lifelines declared with `size: [4, 1220]` — to ELK as a node. Layered then promotes those rails to their own columns and stacks the participant headers at the lifeline midline.
- Fix: a `LabelBox` whose narrower side is ≤10px is a hand-laid-out rail (lifeline / swimlane divider). When any such primitive is present, `buildGraphModel` returns `null` so `compileAsync` falls through to the sync compile path and the declared `at` coordinates survive. Mirrors the existing "Frame present → skip ELK" escape hatch.

## Verification

- New unit tests in `packages/core/test/buildGraphModel.test.ts`: lifeline-containing scene ⇒ `graph === null`; normal scene still builds two nodes.
- New integration test in `packages/core/test/compileAsync.test.ts`: `compileAsync({ useLayout: true })` on a lifeline scene emits the same rectangle X positions as the sync `compile`, i.e. ELK is truly bypassed.
- `pnpm --filter @drawcast/core test -- --run` → 12 files / 131 tests pass.
- Eval re-runs on `seq-oauth-01` (LLM output varies sample-to-sample):
  - before fix: `2026-04-22T05-03-08Z` — lifelines mangled, total 0.476
  - after fix:  `2026-04-22T05-10-30Z` — total 0.667 (no lifelines emitted this sample, but ELK no longer mangles the path)

## Scenario / run metadata

- `question_id`: `seq-oauth-01`
- `category`: `sequence`
- `difficulty`: `medium`
- `status`: `fixed` (regression mode blocked; rubric still below pass because LLM sample variance dominates)

## Test plan

- [x] `pnpm --filter @drawcast/core test -- --run`
- [ ] CI lint / typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of thin, tall diagram elements (like lifelines) to ensure correct coordinate positioning during compilation and layout processing.

* **Tests**
  * Added test coverage for thin lifeline elements and layout fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->