### PR TITLE
chore(evals): record automation run 20260422-150142-3805

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -1,1 +1,2 @@
 {"run_id":"20260422-050211-8678","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-22T05:21:00Z"}
+{"run_id":"20260422-150142-3805","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-22T06:04:20Z"}


### PR DESCRIPTION
## Summary
- Append history entry for automation run `20260422-150142-3805`.
- Scenario: `state-order-01` (state/easy) — `rubric pass`, `total=0.81`.
- No code changes; history-only update so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-order-01 --n 1` → pass_rate=1, failures=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)