### PR TITLE
chore(evals): record automation run 20260422-070216-9ffe

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -1,2 +1,3 @@
 {"run_id":"20260422-050211-8678","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-22T05:21:00Z"}
 {"run_id":"20260422-150142-3805","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-22T06:04:20Z"}
+{"run_id":"20260422-070216-9ffe","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-22T07:07:27Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260422-070216-9ffe`: `mind-react-01` (mind/medium)
- Verdict: **pass** — rubric total=1, structure=5, labels=5, layout=3, readability=3, intent_fit=5
- Structure: node_count=17, edge_count=16, concept_coverage=1.0, overlap_pairs=0

No code changes — appending history entry only.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation evaluation records.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->