### PR TITLE
chore(evals): record automation run 20260422-090139-e365

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -2,3 +2,4 @@
 {"run_id":"20260422-150142-3805","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-22T06:04:20Z"}
 {"run_id":"20260422-070216-9ffe","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-22T07:07:27Z"}
 {"run_id":"20260422-072500-arch4","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-22T08:05:00Z"}
+{"run_id":"20260422-090139-e365","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-22T09:03:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260422-090139-e365` — `flow-signup-02` (flowchart/medium).
- Rubric `pass` (structure 5 / labels 5 / layout 3 / readability 3 / intent_fit 5), structure metric within bounds (10 nodes / 11 edges, concept_coverage 1.0, has_branch).
- No code changes required; appending `_history.jsonl` so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-signup-02 --n 1` (pass_rate=1)
- [x] Reviewed rendered PNG for overlaps / missing concepts (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation automation run records with new test execution data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->