### PR TITLE
chore(evals): record automation run 20260422-100125-2046

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -3,3 +3,4 @@
 {"run_id":"20260422-070216-9ffe","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-22T07:07:27Z"}
 {"run_id":"20260422-072500-arch4","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-22T08:05:00Z"}
 {"run_id":"20260422-090139-e365","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-22T09:03:00Z"}
+{"run_id":"20260422-100125-2046","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-22T10:05:33Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260422-100125-2046`
- Scenario: `org-startup-01` (category=org, difficulty=easy)
- Status: **pass** — rubric total 0.952, no major issues, overlap_pairs=0

Appends one line to `evals/automation-runs/_history.jsonl` so subsequent loops can apply diversification rules.

## Test plan
- [x] E2E eval: `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → verdict=pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new test execution record to automation run history log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->