### PR TITLE
chore(evals): record automation run 20260422-110137-erd1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -4,3 +4,4 @@
 {"run_id":"20260422-072500-arch4","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-22T08:05:00Z"}
 {"run_id":"20260422-090139-e365","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-22T09:03:00Z"}
 {"run_id":"20260422-100125-2046","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-22T10:05:33Z"}
+{"run_id":"20260422-110137-erd1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-22T11:03:00Z"}


### PR DESCRIPTION
## Summary

- Automation loop run for `erd-blog-01` (erd, easy) passed on first attempt — total=0.952, no overlaps.
- No code changes; only appends one line to `evals/automation-runs/_history.jsonl` so the next loop can apply diversification rules.

## Run details

- run_id: `20260422-110137-erd1`
- eval_run: `2026-04-22T11-02-44Z`
- metrics: node=5 (fit=1), edge=5 (fit=1), concept_coverage=1, overlap_pairs=0
- rubric: structure=4, labels=5, layout=3, readability=3, intent_fit=5

## Test plan

- [x] `pnpm --filter drawcast-evals eval -- --id erd-blog-01 --n 1` → pass_rate=1