### PR TITLE
chore(evals): record automation run 20260422-120000-net1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -5,3 +5,4 @@
 {"run_id":"20260422-090139-e365","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-22T09:03:00Z"}
 {"run_id":"20260422-100125-2046","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-22T10:05:33Z"}
 {"run_id":"20260422-110137-erd1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-22T11:03:00Z"}
+{"run_id":"20260422-120000-net1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-22T12:05:02Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for net-home-01 (network/medium).
- Verdict: **pass** (total 0.905). Structure metrics all fit; concept coverage 100%.
- No code changes needed; appends a single line to `evals/automation-runs/_history.jsonl` so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id net-home-01 --n 1` → pass_rate=1, failures=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->