### PR TITLE
chore(evals): record automation run 20260422-130000-flci

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -6,3 +6,4 @@
 {"run_id":"20260422-100125-2046","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-22T10:05:33Z"}
 {"run_id":"20260422-110137-erd1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-22T11:03:00Z"}
 {"run_id":"20260422-120000-net1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-22T12:05:02Z"}
+{"run_id":"20260422-130000-flci","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-22T13:10:00Z"}


### PR DESCRIPTION
## Summary
- flow-ci-04 (flowchart / hard) 자동화 루프 실행 기록 1줄 추가.
- 1차 샘플 borderline(0.667) 후 2차 샘플 pass(0.905)로 상태 `pass` 기록.

## Test plan
- [x] 파일 변경은 `evals/automation-runs/_history.jsonl` 1줄 append뿐.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation automation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->