### PR TITLE
chore(evals): record automation run 20260422-140000-arcm2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -7,3 +7,4 @@
 {"run_id":"20260422-110137-erd1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-22T11:03:00Z"}
 {"run_id":"20260422-120000-net1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-22T12:05:02Z"}
 {"run_id":"20260422-130000-flci","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-22T13:10:00Z"}
+{"run_id":"20260422-140000-arcm2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-22T14:05:00Z"}


### PR DESCRIPTION
## Summary
- arch-micro-02 (architecture/medium) — pass on first run (rubric 0.905).
- No code changes; history-only chore PR per automation workflow step 7.

## Run details
- run_id: 20260422-140000-arcm2
- eval run_dir: `evals/results/2026-04-22T14-03-19Z`
- metrics: node=8 (fit 8–14), edge=9 (fit 7–16), concept_coverage=1, overlaps=0
- rubric: structure 4 / labels 5 / layout 3 / readability 3 / intent_fit 4

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-micro-02 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)