### PR TITLE
chore(evals): record automation run 20260423-000000-saga3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -8,3 +8,4 @@
 {"run_id":"20260422-120000-net1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-22T12:05:02Z"}
 {"run_id":"20260422-130000-flci","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-22T13:10:00Z"}
 {"run_id":"20260422-140000-arcm2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-22T14:05:00Z"}
+{"run_id":"20260423-000000-saga3","question_id":"seq-saga-03","category":"sequence","difficulty":"hard","status":"gave-up","ts":"2026-04-22T15:27:00Z"}


### PR DESCRIPTION
## Summary

- Appends `_history.jsonl` line for automation run `20260423-000000-saga3` (status=`gave-up`).
- Scenario: `seq-saga-03` / sequence / hard.
- No code changes — 4 iteration attempts on category-aware prompt hints in `evals/runner/claude-client.ts` did not consistently reach `pass` (threshold total ≥ 0.7 with all axes ≥ 2). Runs: 0.571 / 0.667 / 0.619 / 0.619 (all borderline). Structure metric `node_count_fit` did flip 0 → 1 and output shifted to sequence-diagram style, but participant ordering was unstable. Prompt change reverted; retry after we have multi-sample variance control.

## Test plan

- [x] `_history.jsonl` valid JSONL (one new line appended).
- [x] No other files changed (`git diff --stat` = 1 file, +1 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation automation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->