### PR TITLE
chore(evals): record automation run 20260423-010000-tcp2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -9,3 +9,4 @@
 {"run_id":"20260422-130000-flci","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-22T13:10:00Z"}
 {"run_id":"20260422-140000-arcm2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-22T14:05:00Z"}
 {"run_id":"20260423-000000-saga3","question_id":"seq-saga-03","category":"sequence","difficulty":"hard","status":"gave-up","ts":"2026-04-22T15:27:00Z"}
+{"run_id":"20260423-010000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-22T16:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-010000-tcp2`
- Scenario: `state-tcp-02` (state / medium)
- Status: **pass** — rubric 0.952, all structure metrics fit (nodes=11, edges=17, concept coverage 1.0, zero overlap).
- No code change required; only `_history.jsonl` append so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-tcp-02 --n 1` → verdict=pass