### PR TITLE
chore(evals): record automation run 20260423-020000-erdm2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -10,3 +10,4 @@
 {"run_id":"20260422-140000-arcm2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-22T14:05:00Z"}
 {"run_id":"20260423-000000-saga3","question_id":"seq-saga-03","category":"sequence","difficulty":"hard","status":"gave-up","ts":"2026-04-22T15:27:00Z"}
 {"run_id":"20260423-010000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-22T16:05:00Z"}
+{"run_id":"20260423-020000-erdm2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-23T02:05:00Z"}


### PR DESCRIPTION
## Summary
- erd-ecom-02 (erd/medium) — first-try pass (rubric + structure metrics).
- No code changes; only appends history line for diversification bookkeeping.

## Metrics
- node_count=5 (fit=1), edge_count=4 (fit=1)
- concept_coverage=1.0 (User/Product/Order/OrderItem/Payment)
- overlap_pairs=0, edge_label_overlaps=0
- rubric verdict=pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->