### PR TITLE
fix(mcp): clarify draw_upsert_box `at` is the CENTER of the box

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -11,3 +11,4 @@
 {"run_id":"20260423-000000-saga3","question_id":"seq-saga-03","category":"sequence","difficulty":"hard","status":"gave-up","ts":"2026-04-22T15:27:00Z"}
 {"run_id":"20260423-010000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-22T16:05:00Z"}
 {"run_id":"20260423-020000-erdm2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-23T02:05:00Z"}
+{"run_id":"20260423-030000-vpcx","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"fixed","ts":"2026-04-23T03:12:00Z"}

--- a/packages/mcp-server/src/tools/drawUpsertBox.ts
+++ b/packages/mcp-server/src/tools/drawUpsertBox.ts
@@ -59,7 +59,7 @@ export const drawUpsertBoxInputSchema = z.object({
 export type DrawUpsertBoxInput = z.infer<typeof drawUpsertBoxInputSchema>;
 
 const DESCRIPTION =
-  'Add or update a labeled box in the current scene. Use this for nodes in a diagram (process, decision, data, etc.). Same id re-applies as an update (upsert). Size auto-fits to text unless fit="fixed" with explicit size. Omit `at` to let the layout engine pick a position — only pass explicit coordinates when the user specifically asked to pin or place the box. Pass `returnPreview: true` to receive a PNG snapshot of the scene after the upsert for visual self-review.';
+  'Add or update a labeled box in the current scene. Use this for nodes in a diagram (process, decision, data, etc.). Same id re-applies as an update (upsert). Size auto-fits to text unless fit="fixed" with explicit size. Omit `at` to let the layout engine pick a position — only pass explicit coordinates when the user specifically asked to pin or place the box. `at` is the CENTER of the box (not the top-left); when placing boxes inside a `draw_upsert_frame` whose `at` is the frame top-left, remember to offset by half the box size so children stay inside the frame. Pass `returnPreview: true` to receive a PNG snapshot of the scene after the upsert for visual self-review.';
 
 export const drawUpsertBox = defineTool({
   name: 'draw_upsert_box',
@@ -78,7 +78,7 @@ export const drawUpsertBox = defineTool({
       at: {
         ...POINT_JSON_SCHEMA,
         description:
-          'Scene coordinate [x, y]. Optional — omit to let the layout engine place the box. Provide only when the user explicitly asked to pin a position.',
+          'Scene coordinate [x, y] of the box CENTER (not top-left). The rendered rect spans [x - width/2, y - height/2] to [x + width/2, y + height/2]. Optional — omit to let the layout engine place the box. Provide only when the user explicitly asked to pin a position. When placing inside a frame (whose `at` is top-left), add half the box size to the desired inner offset so the shape stays inside the frame bounds.',
       },
       style: STYLE_REF_JSON_SCHEMA,
       fit: {

--- a/packages/mcp-server/test/tools.box.test.ts
+++ b/packages/mcp-server/test/tools.box.test.ts
@@ -175,6 +175,24 @@ describe('draw_upsert_box', () => {
     expect(result.content[0]).toMatchObject({ type: 'text' });
   });
 
+  it('documents that `at` is the CENTER of the box in both the tool description and the schema', () => {
+    // Regression: `labelBox.at` is a CENTER point (see
+    // @drawcast/core src/emit/labelBox.ts), but `draw_upsert_frame.at`
+    // is a top-left. Without clarifying this in the tool schema, LLM
+    // authors put box children outside their parent frame bounds (they
+    // assume `at` == top-left, matching frames). The MCP schema is the
+    // single source of truth the LLM sees — these assertions keep the
+    // CENTER/top-left distinction from silently regressing.
+    expect(drawUpsertBox.description).toMatch(/CENTER of the box/);
+    const atSchema = (
+      drawUpsertBox.jsonSchema as {
+        properties: { at: { description: string } };
+      }
+    ).properties.at;
+    expect(atSchema.description).toMatch(/CENTER/);
+    expect(atSchema.description).toMatch(/x - width\/2/);
+  });
+
   it('converts a literal \\n inside the text into a real newline', async () => {
     // Regression: some MCP clients double-encode newlines as the two
     // characters `\` + `n`, which would otherwise land in Excalidraw as


### PR DESCRIPTION
## Summary
- `draw_upsert_box.at` is interpreted as a CENTER by `@drawcast/core`'s emit pipeline, but `draw_upsert_frame.at` is a top-left. The MCP tool description didn't spell this out, so authoring LLMs placed box children outside their parent frame (matching frames' top-left semantics).
- Tool description + `at` schema description now make the CENTER convention explicit and call out the offset needed when dropping boxes inside a frame.
- Added a regression test that pins the CENTER wording in both the tool description and the JSON schema so it can't silently revert.

## Evaluation evidence
Scenario: `net-vpc-02` (network, hard) from the golden set.

| | total | verdict | layout | readability | structure | labels | intent_fit |
|-|-------|---------|--------|-------------|-----------|--------|------------|
| before | 0.667 | fail | 1 | 1 | 4 | 4 | 4 |
| after  | 0.762 | **pass** | 2 | 2 | 4 | 4 | 4 |

Before — Public/Private Subnet frame children clipped left (`Public 라우트 테이블` → `blic 라우트 테이블`, `ALB`/`NAT Gateway` cut):
`evals/results/2026-04-22T18-02-42Z/net-vpc-02.sample-1.png`

After — children sit inside their frames, no clipping:
`evals/results/2026-04-22T18-10-34Z/net-vpc-02.sample-1.png`

## Run metadata
- run_id: `20260423-030000-vpcx`
- question_id: `net-vpc-02`, category: `network`, difficulty: `hard`
- status: `fixed`
- `evals/automation-runs/_history.jsonl` updated in this PR.

## Test plan
- [x] `pnpm --filter @drawcast/mcp-server test -- tools.box` — 12 passed (includes new regression test).
- [x] `pnpm --filter drawcast-evals eval -- --id net-vpc-02 --n 1` — verdict=pass, total=0.762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that box drawing tool coordinates reference the center point, with guidance for calculating frame offsets.

* **Tests**
  * Added regression test to verify coordinate positioning documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->