### PR TITLE
chore(evals): record automation run 20260423-040000-orgs1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -12,3 +12,4 @@
 {"run_id":"20260423-010000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-22T16:05:00Z"}
 {"run_id":"20260423-020000-erdm2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-23T02:05:00Z"}
 {"run_id":"20260423-030000-vpcx","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"fixed","ts":"2026-04-23T03:12:00Z"}
+{"run_id":"20260423-040000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T04:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-040000-orgs1` — scenario `org-startup-01` (org/easy) passed on first try.
- rubric total 0.952 (structure=4, labels=5, layout=3, readability=3, intent_fit=5), node_count=9/edge_count=8 fit, concept_coverage=1.
- No code changes; only appending to `_history.jsonl` so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass_rate=1, overlap_free_rate=1