### PR TITLE
chore(evals): record automation run 20260423-050000-mind1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -13,3 +13,4 @@
 {"run_id":"20260423-020000-erdm2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-23T02:05:00Z"}
 {"run_id":"20260423-030000-vpcx","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"fixed","ts":"2026-04-23T03:12:00Z"}
 {"run_id":"20260423-040000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T04:05:00Z"}
+{"run_id":"20260423-050000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T05:05:00Z"}


### PR DESCRIPTION
## Summary
- mind-react-01 (mind/medium) → pass (rubric 0.952, strict_pass, overlap_free)
- History-only update; no code changes.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → verdict=pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->