### PR TITLE
chore(evals): record automation run 20260423-060000-retr

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -14,3 +14,4 @@
 {"run_id":"20260423-030000-vpcx","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"fixed","ts":"2026-04-23T03:12:00Z"}
 {"run_id":"20260423-040000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T04:05:00Z"}
 {"run_id":"20260423-050000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T05:05:00Z"}
+{"run_id":"20260423-060000-retr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T06:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation run for `flow-retry-05` (flowchart / easy).
- Verdict: **pass** (rubric total 0.952, structure/intent/labels all clean, has_branch + has_loop true, 0 overlaps).
- No code changes — history append only.

## Scenario selection
- Excluded recent 5 ids and previous category (mind).
- All 6 remaining categories tied at 2 uses; random pick among least-used-difficulty candidates.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-retry-05 --n 1` → pass_rate=1, failures=0