### PR TITLE
chore(evals): record automation run 20260423-070000-a3t1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -15,3 +15,4 @@
 {"run_id":"20260423-040000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T04:05:00Z"}
 {"run_id":"20260423-050000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T05:05:00Z"}
 {"run_id":"20260423-060000-retr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T06:05:00Z"}
+{"run_id":"20260423-070000-a3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-23T07:05:00Z"}


### PR DESCRIPTION
## Summary
- `arch-3tier-01` (architecture/easy) passed on first E2E run (total=0.952, verdict=pass).
- No code changes required; appending history entry only so next loop's diversification rules see this run.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-3tier-01 --n 1` → pass_rate=1, failures=0
- [x] PNG 확인: 프론트엔드 → 백엔드 → 데이터베이스 3계층, 겹침·레이블 잘림 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation records.

---

*Note: This release contains minimal internal updates with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->