### PR TITLE
chore(evals): record automation run 20260423-080000-wsseq

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -16,3 +16,4 @@
 {"run_id":"20260423-050000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T05:05:00Z"}
 {"run_id":"20260423-060000-retr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T06:05:00Z"}
 {"run_id":"20260423-070000-a3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-23T07:05:00Z"}
+{"run_id":"20260423-080000-wsseq","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-23T08:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-080000-wsseq` — scenario `seq-websocket-02` (sequence/easy)
- Result: **pass** (rubric pass, concept_coverage=1, overlap=0). No code changes.
- Append one line to `evals/automation-runs/_history.jsonl` so next loop can apply diversification rules.

## Test plan
- [x] Eval executed: `pnpm --filter drawcast-evals eval -- --id seq-websocket-02 --n 1` → pass_rate=1
- [x] PNG reviewed at `evals/results/2026-04-22T23-02-45Z/seq-websocket-02.sample-1.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added evaluation automation run record to internal tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->