### PR TITLE
chore(evals): record automation run 20260423-090000-erdh3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -17,3 +17,4 @@
 {"run_id":"20260423-060000-retr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T06:05:00Z"}
 {"run_id":"20260423-070000-a3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-23T07:05:00Z"}
 {"run_id":"20260423-080000-wsseq","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-23T08:05:00Z"}
+{"run_id":"20260423-090000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-23T09:05:00Z"}


### PR DESCRIPTION
## Summary
- Append `_history.jsonl` for automation run `20260423-090000-erdh3`.
- question_id: `erd-hospital-03` (erd / hard)
- status: `pass` (rubric total 0.948, verdict pass, concept_coverage 1.0)

## Test plan
- [x] E2E eval ran: `pnpm --filter drawcast-evals eval -- --id erd-hospital-03 --n 1` → pass, pass_rate 1