### PR TITLE
chore(evals): record automation run 20260423-110000-nhome

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -19,3 +19,4 @@
 {"run_id":"20260423-080000-wsseq","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-23T08:05:00Z"}
 {"run_id":"20260423-090000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-23T09:05:00Z"}
 {"run_id":"20260423-100000-elv3","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-23T10:05:00Z"}
+{"run_id":"20260423-110000-nhome","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-23T11:05:00Z"}


### PR DESCRIPTION
## Summary
- Record automation loop run `20260423-110000-nhome` in `evals/automation-runs/_history.jsonl`.
- Scenario: `net-home-01` (network / medium) — passed on first try (total 0.857, verdict pass).
- No code changes; history-only chore PR per automation workflow.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id net-home-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded a successful automation test run entry to maintain testing infrastructure logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->