### PR TITLE
chore(evals): record automation run 20260423-120000-mind1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -20,3 +20,4 @@
 {"run_id":"20260423-090000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-23T09:05:00Z"}
 {"run_id":"20260423-100000-elv3","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-23T10:05:00Z"}
 {"run_id":"20260423-110000-nhome","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-23T11:05:00Z"}
+{"run_id":"20260423-120000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T12:05:00Z"}


### PR DESCRIPTION
## Summary
- mind-react-01 (mind/medium) 자동 평가 `pass` 기록.
- 코드 변경 없음. `_history.jsonl` 1줄 append.

## Run 세부
- run_id: `20260423-120000-mind1`
- verdict: `pass` (rubric pass, node 17 / edge 16, concept_coverage 1.0, overlap 0)
- result_dir: `evals/results/2026-04-23T09-03-19Z/`

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test automation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->