### PR TITLE
chore(evals): record automation run 20260423-140000-cqrs1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -22,3 +22,4 @@
 {"run_id":"20260423-110000-nhome","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-23T11:05:00Z"}
 {"run_id":"20260423-120000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T12:05:00Z"}
 {"run_id":"20260423-130000-sord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-23T13:05:00Z"}
+{"run_id":"20260423-140000-cqrs1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-23T14:05:00Z"}


### PR DESCRIPTION
## Summary
- question_id: `arch-eventdriven-05` (architecture / hard)
- verdict: **pass** (total 0.848, rubric structure 4 / labels 5 / layout 2 / readability 3 / intent_fit 4)
- 코드 변경 없음. `_history.jsonl`만 1줄 append.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-eventdriven-05 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test automation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->