### PR TITLE
chore(evals): record automation run 20260423-150000-vpcr

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -23,3 +23,4 @@
 {"run_id":"20260423-120000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-23T12:05:00Z"}
 {"run_id":"20260423-130000-sord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-23T13:05:00Z"}
 {"run_id":"20260423-140000-cqrs1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-23T14:05:00Z"}
+{"run_id":"20260423-150000-vpcr","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-23T15:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-150000-vpcr` — `net-vpc-02` (network/hard) 재검증.
- verdict: `pass` (total 0.952). 이전 루프 `20260423-030000-vpcx`에서 fixed로 병합된 개선이 회귀 없이 유지됨.
- 코드 변경 없음. `_history.jsonl` 한 줄만 추가.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id net-vpc-02 --n 1` → pass_rate=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->