### PR TITLE
chore(evals): record automation run 20260423-160000-orgs1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -24,3 +24,4 @@
 {"run_id":"20260423-130000-sord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-23T13:05:00Z"}
 {"run_id":"20260423-140000-cqrs1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-23T14:05:00Z"}
 {"run_id":"20260423-150000-vpcr","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-23T15:05:00Z"}
+{"run_id":"20260423-160000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T16:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-160000-orgs1`
- question_id: `org-startup-01` (org / easy)
- status: `pass` (rubric total 0.905, no code change)

## Metrics
- node_count=9 (fit=1), edge_count=8 (fit=1), concept_coverage=1, overlap_pairs=0
- rubric: structure=4, labels=5, layout=2, readability=3, intent_fit=5

## Test plan
- [x] eval run passes (`evals/results/2026-04-23T13-03-57Z/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)