### PR TITLE
chore(evals): record automation run 20260423-170000-flog1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -25,3 +25,4 @@
 {"run_id":"20260423-140000-cqrs1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-23T14:05:00Z"}
 {"run_id":"20260423-150000-vpcr","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-23T15:05:00Z"}
 {"run_id":"20260423-160000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T16:05:00Z"}
+{"run_id":"20260423-170000-flog1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T17:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-170000-flog1` — `flow-login-01` (flowchart/easy).
- Verdict: **pass** (structure fit=1, rubric verdict=pass, concept_coverage=1, no overlaps).
- History-only change; no code modifications.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-login-01 --n 1` → pass_rate=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded successful automated test run completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->