### PR TITLE
chore(evals): record automation run 20260423-180000-pmt1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -26,3 +26,4 @@
 {"run_id":"20260423-150000-vpcr","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-23T15:05:00Z"}
 {"run_id":"20260423-160000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T16:05:00Z"}
 {"run_id":"20260423-170000-flog1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T17:05:00Z"}
+{"run_id":"20260423-180000-pmt1","question_id":"seq-payment-04","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-23T18:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260423-180000-pmt1`
- Scenario: `seq-payment-04` (sequence / hard)
- Status: **pass** (rubric total 0.756; pass_rate=1, strict_pass_rate=1)
- No code changes — history entry only.

## Notes
Required concepts all covered; no overlaps; branch present. Known sequence-as-flowchart quality gap persists (same pattern seen in prior `seq-saga-03` gave-up) but runner verdict is pass and no concrete minimal hypothesis emerged within the 4-iteration budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation test run records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->