### PR TITLE
chore(evals): record automation run 20260424-000000-erdb1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -27,3 +27,4 @@
 {"run_id":"20260423-160000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-23T16:05:00Z"}
 {"run_id":"20260423-170000-flog1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T17:05:00Z"}
 {"run_id":"20260423-180000-pmt1","question_id":"seq-payment-04","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-23T18:05:00Z"}
+{"run_id":"20260424-000000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-24T00:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop selected `erd-blog-01` (erd/easy) per diversification rules (min-usage category tie-broken by difficulty spread).
- First-try pass: rubric structure/labels/layout/readability/intent_fit = 5/5/3/3/5, concept_coverage=1.0, overlap_pairs=0, edge_label_overlaps=0.
- No code changes; history-only update.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id erd-blog-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)