### PR TITLE
chore(evals): record automation run 20260424-010000-mind3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -28,3 +28,4 @@
 {"run_id":"20260423-170000-flog1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-23T17:05:00Z"}
 {"run_id":"20260423-180000-pmt1","question_id":"seq-payment-04","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-23T18:05:00Z"}
 {"run_id":"20260424-000000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-24T00:05:00Z"}
+{"run_id":"20260424-010000-mind3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T01:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260424-010000-mind3` — scenario `mind-react-01` (mind / medium), status **pass** (rubric total 0.952, pass_rate 1).
- `_history.jsonl` 단독 업데이트. 코드 변경 없음.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation testing records.

---

**Note:** This update contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->