### PR TITLE
chore(evals): record automation run 20260424-020000-fsu2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -29,3 +29,4 @@
 {"run_id":"20260423-180000-pmt1","question_id":"seq-payment-04","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-23T18:05:00Z"}
 {"run_id":"20260424-000000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-24T00:05:00Z"}
 {"run_id":"20260424-010000-mind3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T01:05:00Z"}
+{"run_id":"20260424-020000-fsu2","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-24T02:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260424-020000-fsu2` recorded.
- Scenario: `flow-signup-02` (flowchart/medium) — **pass**, rubric total 0.952.
- No code changes; history-only chore PR to preserve diversification state in main.

## Metrics
- node_count=8, edge_count=8, node_count_fit=1, edge_count_fit=1
- concept_coverage=1, overlap_pairs=0, edge_label_overlaps=0, has_branch=true
- rubric: structure 5 / labels 5 / layout 3 / readability 2 / intent_fit 5

## Test plan
- [x] Eval runner passes for `flow-signup-02` (`pnpm --filter drawcast-evals eval -- --id flow-signup-02 --n 1`)
- [x] History line appended exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->