### PR TITLE
chore(evals): record automation run 20260424-030000-orgs4

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -30,3 +30,4 @@
 {"run_id":"20260424-000000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-24T00:05:00Z"}
 {"run_id":"20260424-010000-mind3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T01:05:00Z"}
 {"run_id":"20260424-020000-fsu2","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-24T02:05:00Z"}
+{"run_id":"20260424-030000-orgs4","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T03:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for `org-startup-01` (category=org, difficulty=easy).
- Verdict: **pass** (total 0.952). Counts/concept coverage in range, no overlaps.
- No code changes — history-only update.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run records with a new passing test entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->