### PR TITLE
chore(evals): record automation run 20260424-050000-soth1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -32,3 +32,4 @@
 {"run_id":"20260424-020000-fsu2","question_id":"flow-signup-02","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-24T02:05:00Z"}
 {"run_id":"20260424-030000-orgs4","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T03:05:00Z"}
 {"run_id":"20260424-040000-amic2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-24T04:05:00Z"}
+{"run_id":"20260424-050000-soth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-24T05:05:00Z"}


### PR DESCRIPTION
## Summary
- seq-oauth-01 (sequence/medium) 자동화 루프 통과 기록.
- rubric total 0.714, verdict=pass; node_count_fit=1, edge_count_fit=1, concept_coverage=1, overlap=0.
- 코드 변경 없음 — _history.jsonl 1줄 append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test automation run record for OAuth sequence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->