### PR TITLE
chore(evals): record automation run 20260424-060000-erde2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -33,3 +33,4 @@
 {"run_id":"20260424-030000-orgs4","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T03:05:00Z"}
 {"run_id":"20260424-040000-amic2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-24T04:05:00Z"}
 {"run_id":"20260424-050000-soth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-24T05:05:00Z"}
+{"run_id":"20260424-060000-erde2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-24T06:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260424-060000-erde2` — scenario `erd-ecom-02` (erd/medium) passed with total 0.952
- No code changes; this PR only appends the history entry so the next loop can apply diversification rules

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id erd-ecom-02 --n 1` → pass (rubric pass, structure fit)