### PR TITLE
chore(evals): record automation run 20260424-070000-tcp2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -34,3 +34,4 @@
 {"run_id":"20260424-040000-amic2","question_id":"arch-micro-02","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-24T04:05:00Z"}
 {"run_id":"20260424-050000-soth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-24T05:05:00Z"}
 {"run_id":"20260424-060000-erde2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-24T06:05:00Z"}
+{"run_id":"20260424-070000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-24T07:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260424-070000-tcp2`
- question_id: `state-tcp-02` (category: state, difficulty: medium)
- status: `pass` — rubric total 0.905, node_count=11 (fit), edge_count=18 (fit), concept_coverage=1.0, no overlap
- No code changes; this PR only appends one line to `_history.jsonl` so future loops can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-tcp-02 --n 1` passed (pass_rate=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->