### PR TITLE
chore(evals): record automation run 20260424-080000-nhom2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -35,3 +35,4 @@
 {"run_id":"20260424-050000-soth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-24T05:05:00Z"}
 {"run_id":"20260424-060000-erde2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-24T06:05:00Z"}
 {"run_id":"20260424-070000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-24T07:05:00Z"}
+{"run_id":"20260424-080000-nhom2","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-24T08:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop recorded a `pass` for `net-home-01` (network / medium).
- total=0.905, node_count=8, edge_count=7, concept_coverage=1.0, overlap_pairs=0.
- No code changes — history-only update so subsequent loops can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id net-home-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)