### PR TITLE
chore(evals): record automation run 20260424-090000-orgs5

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -36,3 +36,4 @@
 {"run_id":"20260424-060000-erde2","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-24T06:05:00Z"}
 {"run_id":"20260424-070000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-24T07:05:00Z"}
 {"run_id":"20260424-080000-nhom2","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-24T08:05:00Z"}
+{"run_id":"20260424-090000-orgs5","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T09:05:00Z"}


### PR DESCRIPTION
Automation loop history append for run `20260424-090000-orgs5`.

- question: `org-startup-01` (org / easy)
- status: `pass` (rubric total 0.952, no code change)
- eval run dir: `evals/results/2026-04-24T04-02-27Z/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->