### PR TITLE
chore(evals): record automation run 20260424-100000-mind4

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -37,3 +37,4 @@
 {"run_id":"20260424-070000-tcp2","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-24T07:05:00Z"}
 {"run_id":"20260424-080000-nhom2","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-24T08:05:00Z"}
 {"run_id":"20260424-090000-orgs5","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T09:05:00Z"}
+{"run_id":"20260424-100000-mind4","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T10:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260424-100000-mind4`: `mind-react-01` (mind, medium) — **pass** (rubric total 0.952, no code change)
- Appends a single line to `evals/automation-runs/_history.jsonl` so the diversification rule works for the next loop.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass_rate=1, failures=0