### PR TITLE
chore(evals): record automation run 20260424-130000-erdh1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -40,3 +40,4 @@
 {"run_id":"20260424-100000-mind4","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T10:05:00Z"}
 {"run_id":"20260424-110000-sags1","question_id":"seq-saga-03","category":"sequence","difficulty":"hard","status":"fixed","ts":"2026-04-24T11:05:00Z"}
 {"run_id":"20260424-120000-flco1","question_id":"flow-concurrent-06","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-24T12:05:00Z"}
+{"run_id":"20260424-130000-erdh1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-24T13:05:00Z"}


### PR DESCRIPTION
## Summary
- erd-hospital-03 (erd, hard) — pass (rubric total 0.94, pass_rate 1)
- 코드 변경 없음. `_history.jsonl`만 업데이트.

## Metrics
- structure=5, labels=4, layout=3, readability=3, intent_fit=5
- node_count=5 (fit), edge_count=4, concept_coverage=1, overlap_pairs=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation testing infrastructure to record additional test run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->