### PR TITLE
chore(evals): record automation run 20260424-150000-stord

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -42,3 +42,4 @@
 {"run_id":"20260424-120000-flco1","question_id":"flow-concurrent-06","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-24T12:05:00Z"}
 {"run_id":"20260424-130000-erdh1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-24T13:05:00Z"}
 {"run_id":"20260424-140000-arch3","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-24T14:05:00Z"}
+{"run_id":"20260424-150000-stord","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-24T15:05:00Z"}


### PR DESCRIPTION
## Summary
- Scheduled automation loop run.
- question_id: `state-order-01` (state/easy)
- status: `pass` (rubric total 0.905; all 5 required states + transitions rendered cleanly)

No code changes — history-only commit so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-order-01 --n 1` → pass (results in `evals/results/2026-04-24T10-02-20Z/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test automation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->