### PR TITLE
chore(evals): record automation run 20260424-220000-org1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -45,3 +45,4 @@
 {"run_id":"20260424-150000-stord","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-24T15:05:00Z"}
 {"run_id":"20260424-160000-vpcr2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"no-change","ts":"2026-04-24T16:05:00Z"}
 {"run_id":"20260424-210040-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T21:05:00Z"}
+{"run_id":"20260424-220000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T22:05:00Z"}


### PR DESCRIPTION
## Summary
- run_id: 20260424-220000-org1
- question_id: org-startup-01 (org / easy)
- status: pass (total=0.952, rubric pass)
- 코드 변경 없음 — history만 추가

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation records to track additional automation run metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->