### PR TITLE
chore(evals): record automation run 20260424-230000-wsk1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -46,3 +46,4 @@
 {"run_id":"20260424-160000-vpcr2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"no-change","ts":"2026-04-24T16:05:00Z"}
 {"run_id":"20260424-210040-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T21:05:00Z"}
 {"run_id":"20260424-220000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T22:05:00Z"}
+{"run_id":"20260424-230000-wsk1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-24T23:05:00Z"}


### PR DESCRIPTION
## Summary
- Scheduled automation loop run for `seq-websocket-02` (sequence/easy)
- Result: `pass` (total 0.857, node/edge counts fit, concept coverage 1.0)
- No code changes; history-only commit to keep diversification rules working

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id seq-websocket-02 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->