### PR TITLE
chore(evals): record automation run 20260425-000000-cdn1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -47,3 +47,4 @@
 {"run_id":"20260424-210040-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-24T21:05:00Z"}
 {"run_id":"20260424-220000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T22:05:00Z"}
 {"run_id":"20260424-230000-wsk1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-24T23:05:00Z"}
+{"run_id":"20260425-000000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-25T00:05:00Z"}


### PR DESCRIPTION
## Summary
- arch-cdn-03 (architecture/medium) automation run passed: rubric total 0.762, node/edge counts fit, concept coverage 1.
- Records history row so the next automation loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --n 1` → pass (verdict=pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new automation test run entry recording a passing result for architecture validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->