### PR TITLE
chore(evals): record automation run 20260425-010000-erdb1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -48,3 +48,4 @@
 {"run_id":"20260424-220000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-24T22:05:00Z"}
 {"run_id":"20260424-230000-wsk1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-24T23:05:00Z"}
 {"run_id":"20260425-000000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-25T00:05:00Z"}
+{"run_id":"20260425-010000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-25T01:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260425-010000-erdb1` (erd-blog-01, erd/easy).
- Result: pass (total 0.905); node/edge/concept fit all 1.0, no overlaps.
- No code changes — single `_history.jsonl` append for diversification bookkeeping.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id erd-blog-01 --n 1` → pass (rubric 0.905).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal automation records.

---

**Note:** This release contains primarily internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->