### PR TITLE
chore(evals): record automation run 20260425-020000-d152

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -49,3 +49,4 @@
 {"run_id":"20260424-230000-wsk1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-24T23:05:00Z"}
 {"run_id":"20260425-000000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-25T00:05:00Z"}
 {"run_id":"20260425-010000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-25T01:05:00Z"}
+{"run_id":"20260425-020000-d152","question_id":"flow-order-03","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-25T02:05:00Z"}


### PR DESCRIPTION
## Summary
- flow-order-03 (flowchart/medium) — pass on first eval run, no code changes required.
- Appends one line to `evals/automation-runs/_history.jsonl` so future loops can apply the diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-order-03 --n 1` → pass_rate=1