### PR TITLE
chore(evals): record automation run 20260425-030000-stev1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -50,3 +50,4 @@
 {"run_id":"20260425-000000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-25T00:05:00Z"}
 {"run_id":"20260425-010000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-25T01:05:00Z"}
 {"run_id":"20260425-020000-d152","question_id":"flow-order-03","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-25T02:05:00Z"}
+{"run_id":"20260425-030000-stev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T03:05:00Z"}


### PR DESCRIPTION
## Summary
- state-elevator-03 (state/medium) passed at total 0.917 (strict_pass=1, overlap_free=1).
- No code changes; append-only `_history.jsonl` record so the next automation loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-elevator-03 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation testing records.

---

**Note:** This release contains no user-facing changes. The update is limited to internal testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->