### PR TITLE
chore(evals): record automation run 20260425-040000-nhom1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -51,3 +51,4 @@
 {"run_id":"20260425-010000-erdb1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-25T01:05:00Z"}
 {"run_id":"20260425-020000-d152","question_id":"flow-order-03","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-25T02:05:00Z"}
 {"run_id":"20260425-030000-stev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T03:05:00Z"}
+{"run_id":"20260425-040000-nhom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T04:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop result: net-home-01 (network/medium) → pass (rubric 0.762, all structure metrics fit)
- No code changes required; records the run in `_history.jsonl` so future loops can apply diversification rules.

## Test plan
- [x] E2E eval pass: `pnpm --filter drawcast-evals eval -- --id net-home-01 --n 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation evaluation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->