### PR TITLE
chore(evals): record automation run 20260425-050000-mindr3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -52,3 +52,4 @@
 {"run_id":"20260425-020000-d152","question_id":"flow-order-03","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-25T02:05:00Z"}
 {"run_id":"20260425-030000-stev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T03:05:00Z"}
 {"run_id":"20260425-040000-nhom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T04:05:00Z"}
+{"run_id":"20260425-050000-mindr3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T05:05:00Z"}


### PR DESCRIPTION
## Summary
- Record automation run for `mind-react-01` (mind/medium)
- Status: **pass** (rubric total 0.952, node=17, edge=16, concept coverage 1.0)
- No code changes required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new automation run validation record to tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->