### PR TITLE
chore(evals): record automation run 20260425-060000-orgs1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -53,3 +53,4 @@
 {"run_id":"20260425-030000-stev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T03:05:00Z"}
 {"run_id":"20260425-040000-nhom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T04:05:00Z"}
 {"run_id":"20260425-050000-mindr3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T05:05:00Z"}
+{"run_id":"20260425-060000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T06:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run: `20260425-060000-orgs1`
- Scenario: `org-startup-01` (org / easy) — verdict **pass** (total 0.905)
- No code changes; history line only.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass_rate=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation tracking records.

---

**Note:** This release includes infrastructure updates with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->