### PR TITLE
chore(evals): record automation run 20260425-070000-4e3d

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -54,3 +54,4 @@
 {"run_id":"20260425-040000-nhom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T04:05:00Z"}
 {"run_id":"20260425-050000-mindr3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T05:05:00Z"}
 {"run_id":"20260425-060000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T06:05:00Z"}
+{"run_id":"20260425-070000-4e3d","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-25T07:05:00Z"}


### PR DESCRIPTION
## Summary
- question_id: `arch-mlops-04` (architecture / hard)
- status: `pass` (rubric total 0.857; structure metrics all fit)
- No code changes — history-only update so the next loop can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-mlops-04 --n 1` → pass_rate=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation evaluation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->