### PR TITLE
chore(evals): record automation run 20260425-080000-fretr

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -55,3 +55,4 @@
 {"run_id":"20260425-050000-mindr3","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T05:05:00Z"}
 {"run_id":"20260425-060000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T06:05:00Z"}
 {"run_id":"20260425-070000-4e3d","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-25T07:05:00Z"}
+{"run_id":"20260425-080000-fretr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-25T08:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop recorded a `pass` for `flow-retry-05` (flowchart/easy).
- No code change this loop; history-only update so future loops can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-retry-05 --n 1` → verdict=pass, structure/edge fit=1.0, has_branch+has_loop.