### PR TITLE
fix(emit): skip line-shaped LabelBoxes when detouring straight edges

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -56,3 +56,4 @@
 {"run_id":"20260425-060000-orgs1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T06:05:00Z"}
 {"run_id":"20260425-070000-4e3d","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-25T07:05:00Z"}
 {"run_id":"20260425-080000-fretr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-25T08:05:00Z"}
+{"run_id":"20260425-090000-seqllm","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"fixed","ts":"2026-04-25T09:08:00Z"}

--- a/packages/core/src/emit/connector.ts
+++ b/packages/core/src/emit/connector.ts
@@ -252,6 +252,17 @@ interface ObstacleBBox {
   h: number;
 }
 
+// LabelBoxes thinner than this on either axis are visual lines (e.g. sequence
+// diagram lifelines drawn at width=2) rather than enclosed regions. Sequence
+// messages are MEANT to cross lifelines, so treating them as obstacles forces
+// every horizontal arrow to detour up/down to clear the columns and the bound
+// labels then pile up on the same coordinate (seq-llm-05 regression).
+const LINE_SHAPED_OBSTACLE_THICKNESS = 4;
+
+function isLineShapedBBox(b: ObstacleBBox): boolean {
+  return b.w <= LINE_SHAPED_OBSTACLE_THICKNESS || b.h <= LINE_SHAPED_OBSTACLE_THICKNESS;
+}
+
 /**
  * Liang–Barsky strict-interior test: does the segment `start → end` cross
  * the interior of `b`, or only graze an edge? Returns true iff there is a
@@ -314,6 +325,7 @@ function findBlockingLabelBox(
   for (const [id, record] of ctx.registry) {
     if (excludeIds.has(id)) continue;
     if (record.kind !== 'labelBox') continue;
+    if (isLineShapedBBox(record.bbox)) continue;
     if (segmentCrossesBBoxInterior(start, end, record.bbox)) return record.bbox;
   }
   return null;

--- a/packages/core/test/emit-connector.test.ts
+++ b/packages/core/test/emit-connector.test.ts
@@ -821,6 +821,87 @@ describe('emitConnector — straight-line obstacle detour (arch-cdn-03)', () => 
     }
   });
 
+  it('line-shaped LabelBoxes (sequence-diagram lifelines) do not trigger detours', () => {
+    // Regression: seq-llm-05 emitted vertical "lifeline" rectangles at
+    // width=2 between participant boxes, then horizontal sequence messages
+    // crossing those lifelines. The detour treated each lifeline as an
+    // obstacle, sending every horizontal arrow up to the same y-coordinate
+    // and stacking the bound labels on top of one another (4 label
+    // overlaps in a single scene). Lifelines are visual lines, not enclosed
+    // regions; sequence messages are MEANT to cross them.
+    const userBox: LabelBox = {
+      kind: 'labelBox',
+      id: 'user' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 40],
+      fit: 'fixed',
+      size: [150, 60],
+      text: 'User',
+    };
+    const apiBox: LabelBox = {
+      kind: 'labelBox',
+      id: 'api' as PrimitiveId,
+      shape: 'rectangle',
+      at: [330, 40],
+      fit: 'fixed',
+      size: [150, 60],
+      text: 'API',
+    };
+    const dbBox: LabelBox = {
+      kind: 'labelBox',
+      id: 'db' as PrimitiveId,
+      shape: 'rectangle',
+      at: [580, 40],
+      fit: 'fixed',
+      size: [150, 60],
+      text: 'DB',
+    };
+    // Lifelines: tall thin rectangles (width 2) under each participant.
+    const userLine: LabelBox = {
+      kind: 'labelBox',
+      id: 'l_user' as PrimitiveId,
+      shape: 'rectangle',
+      at: [100, 450],
+      fit: 'fixed',
+      size: [2, 720],
+      text: '',
+    };
+    const apiLine: LabelBox = {
+      kind: 'labelBox',
+      id: 'l_api' as PrimitiveId,
+      shape: 'rectangle',
+      at: [330, 450],
+      fit: 'fixed',
+      size: [2, 720],
+      text: '',
+    };
+    const dbLine: LabelBox = {
+      kind: 'labelBox',
+      id: 'l_db' as PrimitiveId,
+      shape: 'rectangle',
+      at: [580, 450],
+      fit: 'fixed',
+      size: [2, 720],
+      text: '',
+    };
+    // Horizontal sequence message User → API at y=160. The straight line
+    // crosses the User lifeline endpoint and grazes the API lifeline.
+    const msg: Connector = {
+      kind: 'connector',
+      id: 'm1' as PrimitiveId,
+      from: [100, 160],
+      to: [330, 160],
+      routing: 'straight',
+      label: 'request',
+    };
+    const result = compile(
+      makeScene([userBox, apiBox, dbBox, userLine, apiLine, dbLine, msg]),
+    );
+    const arrow = findArrow(result.elements);
+    // Must remain a 2-point straight line — no detour around the lifelines.
+    expect(arrow.points.length).toBe(2);
+  });
+
   it('endpoint-adjacent LabelBoxes (targets of other edges) do not trigger a false detour', () => {
     // "cache" edge Web → Redis must stay straight even though Redis's
     // bbox touches the arrow's end point. `findBlockingLabelBox` excludes


### PR DESCRIPTION
## Summary
- seq-llm-05 (sequence/hard) 자동 평가에서 가로 메시지 화살표가 lifeline을 obstacle로 오인해 모두 4-point elbow로 우회되어 라벨 4건이 한 좌표에 쌓이는 회귀를 수정.
- `findBlockingLabelBox`에서 width 또는 height ≤ 4px 인 LabelBox(시각적 직선; lifeline)는 obstacle 검사에서 제외.

## Eval evidence (seq-llm-05)
| 지표 | Before | After |
| --- | --- | --- |
| verdict | fail | **pass** |
| total | 0.676 | **0.788** |
| edge_label_overlaps | 4 | **0** |
| node_count (expected 5–6) | 10 | **5** |
| concept_coverage | 0.833 | **1.0** |

- before PNG: `evals/results/2026-04-25T01-02-12Z/seq-llm-05.sample-1.png`
- after PNG: `evals/results/2026-04-25T01-07-50Z/seq-llm-05.sample-1.png`

## Tests
- 신규 회귀 테스트: `packages/core/test/emit-connector.test.ts` "line-shaped LabelBoxes (sequence-diagram lifelines) do not trigger detours"
- arch-cdn-03 detour 회귀(Web/Redis/DB 200×65)는 그대로 유지 — 임계값 4px이라 영향 없음.
- `pnpm --filter @drawcast/core test` → 132 passed.

## Automation context
- run_id: `20260425-090000-seqllm`
- category: sequence, difficulty: hard
- `evals/automation-runs/_history.jsonl` 한 줄 추가 포함.

## Test plan
- [x] core unit tests
- [x] golden-set seq-llm-05 단일 케이스 재실행 후 pass 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connector routing to properly handle extremely thin visual elements in diagrams. Connectors spanning between participants now correctly cross through line-shaped obstacles without unnecessary detours, improving sequence diagram rendering clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->