### PR TITLE
chore(evals): record automation run 20260425-100000-erdec

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -57,3 +57,4 @@
 {"run_id":"20260425-070000-4e3d","question_id":"arch-mlops-04","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-25T07:05:00Z"}
 {"run_id":"20260425-080000-fretr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-25T08:05:00Z"}
 {"run_id":"20260425-090000-seqllm","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"fixed","ts":"2026-04-25T09:08:00Z"}
+{"run_id":"20260425-100000-erdec","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-25T10:05:00Z"}


### PR DESCRIPTION
## Summary
- 자동화 루프 결과 기록 (erd-ecom-02 / erd / medium / status=pass)
- rubric total 0.905, node_count_fit=1, edge_count_fit=1, concept_coverage=1.0, 겹침 0
- 코드 변경 없음 — `_history.jsonl` 한 줄 추가만 포함

## Test plan
- [x] E2E: `pnpm --filter drawcast-evals eval -- --id erd-ecom-02 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)