### PR TITLE
chore(evals): record automation run 20260425-110000-stord2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -58,3 +58,4 @@
 {"run_id":"20260425-080000-fretr","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-25T08:05:00Z"}
 {"run_id":"20260425-090000-seqllm","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"fixed","ts":"2026-04-25T09:08:00Z"}
 {"run_id":"20260425-100000-erdec","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-25T10:05:00Z"}
+{"run_id":"20260425-110000-stord2","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-25T11:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop ran scenario `state-order-01` (state, easy).
- Verdict: **pass** without code change (rubric pass; node_count=7/edge_count=7; all required states + branching present).
- Records the run in `_history.jsonl` so the next loop's diversification rule has the latest entry.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-order-01 --n 1` → pass (`evals/results/2026-04-25T03-02-09Z/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run history and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->