### PR TITLE
chore(evals): record automation run 20260425-120000-vpcr3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -59,3 +59,4 @@
 {"run_id":"20260425-090000-seqllm","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"fixed","ts":"2026-04-25T09:08:00Z"}
 {"run_id":"20260425-100000-erdec","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-25T10:05:00Z"}
 {"run_id":"20260425-110000-stord2","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-25T11:05:00Z"}
+{"run_id":"20260425-120000-vpcr3","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-25T12:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run: net-vpc-02 (network/hard) — pass (verdict 0.857)
- No code changes; appending history entry only.

## Test plan
- [x] history line appended only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run history records with a new passed run entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->