### PR TITLE
chore(evals): record automation run 20260425-130000-mndre1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -60,3 +60,4 @@
 {"run_id":"20260425-100000-erdec","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-25T10:05:00Z"}
 {"run_id":"20260425-110000-stord2","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-25T11:05:00Z"}
 {"run_id":"20260425-120000-vpcr3","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-25T12:05:00Z"}
+{"run_id":"20260425-130000-mndre1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T13:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for `mind-react-01` (mind / medium)
- Status: **pass** (no code changes; rubric pass + structure metrics fit)

## Run details
- run_id: `20260425-130000-mndre1`
- node_count=17 (10..18), edge_count=16 (9..18), concept_coverage=1, overlap_pairs=0
- rubric: structure=5, labels=5, layout=3, readability=3, intent_fit=5

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass_rate=1