### PR TITLE
chore(evals): record automation run 20260425-140000-org2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -61,3 +61,4 @@
 {"run_id":"20260425-110000-stord2","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-25T11:05:00Z"}
 {"run_id":"20260425-120000-vpcr3","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-25T12:05:00Z"}
 {"run_id":"20260425-130000-mndre1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T13:05:00Z"}
+{"run_id":"20260425-140000-org2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T14:05:00Z"}


### PR DESCRIPTION
## Summary
- Record automation loop run 20260425-140000-org2 in `_history.jsonl`.
- question_id: org-startup-01 (org, easy)
- status: pass (total=0.905, rubric pass + node/edge count fit, no overlaps)

## Test plan
- [x] eval ran: `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass_rate=1
- [x] history line appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run history tracking with new test result entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->