### PR TITLE
chore(evals): record automation run 20260425-150000-oauth1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -62,3 +62,4 @@
 {"run_id":"20260425-120000-vpcr3","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-25T12:05:00Z"}
 {"run_id":"20260425-130000-mndre1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T13:05:00Z"}
 {"run_id":"20260425-140000-org2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T14:05:00Z"}
+{"run_id":"20260425-150000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-25T15:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260425-150000-oauth1`
- Scenario: `seq-oauth-01` (sequence / medium) — picked per diversity rules (recent-5 exclusion + last-cat exclusion + min cat/difficulty + random tiebreak).
- Result: **pass** (rubric total 0.762, structure metric fit, concept_coverage=1.0, overlap_pairs=0).
- No code changes — history-only chore PR.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id seq-oauth-01 --n 1` passed
- [x] PNG inspected, structure metric within bounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new automation run result record with passing status to evaluation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->