### PR TITLE
chore(evals): record automation run 20260425-160000-erdhos1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -63,3 +63,4 @@
 {"run_id":"20260425-130000-mndre1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T13:05:00Z"}
 {"run_id":"20260425-140000-org2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T14:05:00Z"}
 {"run_id":"20260425-150000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-25T15:05:00Z"}
+{"run_id":"20260425-160000-erdhos1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-25T16:05:00Z"}


### PR DESCRIPTION
## Summary
- Record automation run `20260425-160000-erdhos1` in `_history.jsonl`.
- question: `erd-hospital-03` (erd/hard) — verdict **pass**, no code change.

## Test plan
- [x] eval run pass: nodes=6 (fit), edges=5 (fit), overlap=0, rubric verdict=pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)