### PR TITLE
chore(evals): record automation run 20260425-170000-flowci4

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -64,3 +64,4 @@
 {"run_id":"20260425-140000-org2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T14:05:00Z"}
 {"run_id":"20260425-150000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-25T15:05:00Z"}
 {"run_id":"20260425-160000-erdhos1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-25T16:05:00Z"}
+{"run_id":"20260425-170000-flowci4","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-25T17:05:00Z"}


### PR DESCRIPTION
## Summary
- flow-ci-04 (flowchart, hard) automation run: **pass** (rubric 0.905, node=13, edge=20, branches present, no overlaps).
- Adds a single line to `evals/automation-runs/_history.jsonl` so the next loop sees this category/difficulty.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id flow-ci-04 --n 1` → verdict `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->