### PR TITLE
chore(evals): record automation run 20260425-180000-arch3t1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -65,3 +65,4 @@
 {"run_id":"20260425-150000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"pass","ts":"2026-04-25T15:05:00Z"}
 {"run_id":"20260425-160000-erdhos1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-25T16:05:00Z"}
 {"run_id":"20260425-170000-flowci4","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-25T17:05:00Z"}
+{"run_id":"20260425-180000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-25T18:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop: arch-3tier-01 (architecture/easy) — verdict **pass** (rubric pass, structure fit)
- No code changes; only `_history.jsonl` line append for diversification tracking.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-3tier-01 --n 1` → pass_rate=1, rubric pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)