### PR TITLE
chore(evals): record automation run 20260425-190000-stcp1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -66,3 +66,4 @@
 {"run_id":"20260425-160000-erdhos1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-25T16:05:00Z"}
 {"run_id":"20260425-170000-flowci4","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-25T17:05:00Z"}
 {"run_id":"20260425-180000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-25T18:05:00Z"}
+{"run_id":"20260425-190000-stcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T19:05:00Z"}


### PR DESCRIPTION
## Summary
- Append history entry for automation loop run `20260425-190000-stcp1`
- Scenario: `state-tcp-02` (state / medium) — verdict **pass** (0.857)
- No code changes required.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-tcp-02 --n 1` → pass_rate=1, failures=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test automation records.

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->