### PR TITLE
chore(evals): record automation run 20260425-200000-nethom1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -67,3 +67,4 @@
 {"run_id":"20260425-170000-flowci4","question_id":"flow-ci-04","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-25T17:05:00Z"}
 {"run_id":"20260425-180000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-25T18:05:00Z"}
 {"run_id":"20260425-190000-stcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T19:05:00Z"}
+{"run_id":"20260425-200000-nethom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T20:05:00Z"}


### PR DESCRIPTION
## Summary
- net-home-01 (network/medium) — verdict: pass (rubric total 0.762)
- node_count=9, edge_count=8, concept_coverage=1, overlap_pairs=0
- 코드 변경 없음. _history.jsonl에 한 줄 추가만.

## Test plan
- [x] pnpm --filter drawcast-evals eval -- --id net-home-01 --n 1 → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)