### PR TITLE
chore(evals): record automation run 20260425-210000-mind4

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -68,3 +68,4 @@
 {"run_id":"20260425-180000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-25T18:05:00Z"}
 {"run_id":"20260425-190000-stcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T19:05:00Z"}
 {"run_id":"20260425-200000-nethom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T20:05:00Z"}
+{"run_id":"20260425-210000-mind4","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T21:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260425-210000-mind4` — appends one line to `_history.jsonl`.
- Scenario: `mind-react-01` (mind / medium); first-run **pass** (rubric total 0.952, structure_fit + concept_coverage = 1.0, 0 overlaps).
- No code changes.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass_rate=1, failures=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->