### PR TITLE
chore(evals): record automation run 20260425-220000-orgs2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -69,3 +69,4 @@
 {"run_id":"20260425-190000-stcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-25T19:05:00Z"}
 {"run_id":"20260425-200000-nethom1","question_id":"net-home-01","category":"network","difficulty":"medium","status":"pass","ts":"2026-04-25T20:05:00Z"}
 {"run_id":"20260425-210000-mind4","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-25T21:05:00Z"}
+{"run_id":"20260425-220000-orgs2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T22:05:00Z"}


### PR DESCRIPTION
## Summary
- Records org-startup-01 automation run (status=pass) in `evals/automation-runs/_history.jsonl`.
- Selection driven by diversification rules: `org` had the lowest cumulative count (8 vs 9 for all others).
- E2E verdict pass (rubric total 0.952, structure/edge counts within range, no overlaps). No code changes.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass_rate=1, failures=0