### PR TITLE
chore(evals): record automation run 20260426-020000-evd1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -72,3 +72,4 @@
 {"run_id":"20260425-220000-orgs2","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-25T22:05:00Z"}
 {"run_id":"20260426-000000-wsk2","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-26T00:05:00Z"}
 {"run_id":"20260426-010000-flogn1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-26T01:05:00Z"}
+{"run_id":"20260426-020000-evd1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-26T02:05:00Z"}


### PR DESCRIPTION
## Summary
- automation loop run for architecture/hard scenario `arch-eventdriven-05`
- verdict pass (total=0.96, all required concepts covered, Command/Query sides clearly separated)
- no code changes; history-only update so the next loop can apply diversification rules

## Test plan
- [x] history line appended; no other tracked files modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run history with new test execution record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->