### PR TITLE
chore(evals): record automation run 20260426-040000-erdh3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -74,3 +74,4 @@
 {"run_id":"20260426-010000-flogn1","question_id":"flow-login-01","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-26T01:05:00Z"}
 {"run_id":"20260426-020000-evd1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-26T02:05:00Z"}
 {"run_id":"20260426-030000-elev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T03:05:00Z"}
+{"run_id":"20260426-040000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-26T04:05:00Z"}


### PR DESCRIPTION
## Summary
- Record automation loop run `20260426-040000-erdh3` in `_history.jsonl`.
- Scenario `erd-hospital-03` (erd, hard) — verdict `pass` (rubric total 0.908). No code change.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id erd-hospital-03 --n 1` → pass_rate=1, failures=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new automation run result record for testing infrastructure tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->