### PR TITLE
chore(evals): record automation run 20260426-050000-vpc1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -75,3 +75,4 @@
 {"run_id":"20260426-020000-evd1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-26T02:05:00Z"}
 {"run_id":"20260426-030000-elev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T03:05:00Z"}
 {"run_id":"20260426-040000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-26T04:05:00Z"}
+{"run_id":"20260426-050000-vpc1","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T05:05:00Z"}


### PR DESCRIPTION
## Summary
- 자동 평가 루프 결과 기록: net-vpc-02 (network/hard) — pass
- rubric total 0.857, structure metric: node=8, edge=8 (fit), overlap=0
- 코드 변경 없음. _history.jsonl 1줄 append만.

## Test plan
- [x] `_history.jsonl`에 1줄만 추가됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation testing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->