### PR TITLE
chore(evals): record automation run 20260426-060000-mind1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -76,3 +76,4 @@
 {"run_id":"20260426-030000-elev1","question_id":"state-elevator-03","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T03:05:00Z"}
 {"run_id":"20260426-040000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-26T04:05:00Z"}
 {"run_id":"20260426-050000-vpc1","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T05:05:00Z"}
+{"run_id":"20260426-060000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-26T06:05:00Z"}


### PR DESCRIPTION
## Summary
- mind-react-01 (mind/medium) 자동화 루프 결과 기록.
- verdict: pass (total 0.952). 코드 변경 없음 — history 1줄만 추가.

## Test plan
- [x] eval 단일 케이스 실행: pass_rate=1
- [x] PNG 검수 완료, major_issues 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)