### PR TITLE
chore(evals): record automation run 20260426-070000-org1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -77,3 +77,4 @@
 {"run_id":"20260426-040000-erdh3","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-26T04:05:00Z"}
 {"run_id":"20260426-050000-vpc1","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T05:05:00Z"}
 {"run_id":"20260426-060000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-26T06:05:00Z"}
+{"run_id":"20260426-070000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T07:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run `20260426-070000-org1` recorded.
- Scenario: `org-startup-01` (org/easy) → verdict **pass** (total 0.857).
- No code changes; history append only.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` passed (rubric pass + structure fit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal evaluation history records.

---

**Note:** This release contains no user-visible changes. Updates are limited to internal testing and evaluation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->