### PR TITLE
chore(evals): record automation run 20260426-080000-erdblog1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -78,3 +78,4 @@
 {"run_id":"20260426-050000-vpc1","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T05:05:00Z"}
 {"run_id":"20260426-060000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-26T06:05:00Z"}
 {"run_id":"20260426-070000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T07:05:00Z"}
+{"run_id":"20260426-080000-erdblog1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-26T08:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for erd-blog-01 (erd/easy)
- Verdict: pass (total=0.952), no code changes
- Recording history line only

## Test plan
- [x] E2E eval passed (rendered=true, verdict=pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->