### PR TITLE
fix(layout): skip ELK when pinned LabelBoxes have no id-bound edges

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -80,3 +80,4 @@
 {"run_id":"20260426-070000-org1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T07:05:00Z"}
 {"run_id":"20260426-080000-erdblog1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-26T08:05:00Z"}
 {"run_id":"20260426-090000-court1","question_id":"flow-court-07","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-26T09:05:00Z"}
+{"run_id":"20260426-100000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-26T10:15:00Z"}

--- a/packages/core/src/layout/buildGraphModel.ts
+++ b/packages/core/src/layout/buildGraphModel.ts
@@ -93,6 +93,25 @@ export function buildGraphModel(
     }
   }
 
+  // No id-bound edges between LabelBoxes means ELK has no structural
+  // signal to re-layer the graph — and `layered` will still rearrange
+  // the nodes ignoring `elk.position` hints. The seq-oauth-01 eval
+  // produced this shape by drawing OAuth participants as LabelBoxes
+  // and connecting them with raw-Point arrows + raw-Point lifelines:
+  // ELK saw 4 nodes with 0 edges, packed them into one column, and
+  // the rendered actor row no longer matched the hand-laid lifelines.
+  // When at least one node carries a positional hint, fall back to
+  // the sync compile path so the declared `at` survives. Pure auto-
+  // layout scenes (no `at`, no edges) still go through ELK so two
+  // disconnected boxes get a deterministic side-by-side placement.
+  if (
+    nodes.length >= 2 &&
+    edges.length === 0 &&
+    nodes.some((n) => n.fixedPosition !== undefined)
+  ) {
+    return null;
+  }
+
   return {
     id: options.id ?? 'scene',
     diagramType: 'flowchart',

--- a/packages/core/test/buildGraphModel.test.ts
+++ b/packages/core/test/buildGraphModel.test.ts
@@ -255,4 +255,72 @@ describe('buildGraphModel — labelBox size measurement', () => {
     expect(graph).not.toBeNull();
     expect(graph!.children).toHaveLength(2);
   });
+
+  // Regression guard for the seq-oauth-01 follow-up: when a scene has
+  // multiple LabelBoxes pinned with explicit `at` and *no* id-bound
+  // connectors among them — only raw-Point arrows for lifelines and
+  // messages — ELK's `layered` algorithm rearranges the nodes ignoring
+  // the `elk.position` hint because it has no edge structure to layer
+  // around. Trust the LLM's positional intent and short-circuit so the
+  // sync compile path keeps the declared `at`. Hand-laid sequence
+  // diagrams (actor row + lifelines + messages-as-points) end up here.
+  it('returns null when pinned LabelBoxes have no id-bound edges between them', () => {
+    const user: LabelBox = {
+      kind: 'labelBox',
+      id: 'user' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 55],
+      at: [80, 50],
+      text: '사용자',
+    };
+    const auth: LabelBox = {
+      kind: 'labelBox',
+      id: 'auth' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [210, 55],
+      at: [570, 50],
+      text: 'Authorization Server',
+    };
+    const message = {
+      kind: 'connector' as const,
+      id: 'M1' as PrimitiveId,
+      from: [80, 200] as const,
+      to: [570, 200] as const,
+      label: '인증요청',
+    };
+    const graph = buildGraphModel(makeScene([user, auth, message]));
+    expect(graph).toBeNull();
+  });
+
+  it('keeps the graph live when at least one connector binds two LabelBoxes by id', () => {
+    const a: LabelBox = {
+      kind: 'labelBox',
+      id: 'a' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      at: [100, 100],
+      text: 'A',
+    };
+    const b: LabelBox = {
+      kind: 'labelBox',
+      id: 'b' as PrimitiveId,
+      shape: 'rectangle',
+      fit: 'fixed',
+      size: [140, 60],
+      at: [400, 100],
+      text: 'B',
+    };
+    const link = {
+      kind: 'connector' as const,
+      id: 'a_b' as PrimitiveId,
+      from: 'a' as PrimitiveId,
+      to: 'b' as PrimitiveId,
+    };
+    const graph = buildGraphModel(makeScene([a, b, link]));
+    expect(graph).not.toBeNull();
+    expect(graph!.edges).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary
- 시퀀스 다이어그램 회귀 수정: 핀된 LabelBox(actor headers) + raw-Point lifeline/message 조합에서 ELK `layered`가 actor 가로 배치를 재배열하던 버그 해결.
- `buildGraphModel`이 N개 노드 + 0 엣지 그래프를 ELK에 그대로 흘려보내면 `elk.position` hint가 무시돼 actor 헤더가 lifeline과 어긋나게 렌더됨. 핀된 노드가 ≥2개이면서 id-bound 컨넥터가 전혀 없으면 sync compile 경로로 fallback.
- 회귀 테스트 2개 추가 (`packages/core/test/buildGraphModel.test.ts`): 핀된 박스 + raw-Point 메시지만 → null, id-bound 1개 이상 → 정상 그래프 유지.

## Eval evidence (seq-oauth-01, sequence/medium)
- run-id: `20260426-100000-oauth1`
- before: total **0.619** (verdict=fail), structure=2, labels=4, layout=3, readability=3, intent_fit=1
- after:  total **0.905** (verdict=pass), structure=4, labels=5, layout=3, readability=3, intent_fit=4
- before PNG: `evals/results/2026-04-26T01-01-57Z/seq-oauth-01.sample-1.png` — actor 가로순 Auth → Resource → User → Client (어긋남)
- after PNG:  `evals/results/2026-04-26T01-10-17Z/seq-oauth-01.sample-1.png` — User → Client → Auth → Resource (정상)

## Tests added
- `buildGraphModel — labelBox size measurement › returns null when pinned LabelBoxes have no id-bound edges between them`
- `buildGraphModel — labelBox size measurement › keeps the graph live when at least one connector binds two LabelBoxes by id`
- 전체 `@drawcast/core` 134/134 pass.

## Test plan
- [x] `pnpm --filter @drawcast/core test`
- [x] `pnpm --filter drawcast-evals eval -- --id seq-oauth-01 --n 1` (verdict pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout handling for diagram scenes containing positioned elements without connecting links, preserving explicit positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->