### PR TITLE
chore(evals): record automation run 20260426-110000-stord1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -81,3 +81,4 @@
 {"run_id":"20260426-080000-erdblog1","question_id":"erd-blog-01","category":"erd","difficulty":"easy","status":"pass","ts":"2026-04-26T08:05:00Z"}
 {"run_id":"20260426-090000-court1","question_id":"flow-court-07","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-26T09:05:00Z"}
 {"run_id":"20260426-100000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-26T10:15:00Z"}
+{"run_id":"20260426-110000-stord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-26T11:05:00Z"}


### PR DESCRIPTION
state-order-01 (state/easy) — automation loop pass.

- verdict: pass (total 0.905)
- metrics: node=6, edge=7, concept_coverage=1, overlap_pairs=0, has_branch=true
- rubric: structure 5 / labels 5 / layout 2 / readability 2 / intent_fit 5
- 코드 변경 없음, history만 1줄 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation records to track evaluation run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->