### PR TITLE
chore(evals): record automation run 20260426-120000-cdn1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -82,3 +82,4 @@
 {"run_id":"20260426-090000-court1","question_id":"flow-court-07","category":"flowchart","difficulty":"medium","status":"pass","ts":"2026-04-26T09:05:00Z"}
 {"run_id":"20260426-100000-oauth1","question_id":"seq-oauth-01","category":"sequence","difficulty":"medium","status":"fixed","ts":"2026-04-26T10:15:00Z"}
 {"run_id":"20260426-110000-stord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-26T11:05:00Z"}
+{"run_id":"20260426-120000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-26T12:05:00Z"}


### PR DESCRIPTION
## Summary
- arch-cdn-03 (architecture/medium) automation run — `pass` (rubric total 0.762, structure metric fit)
- History-only append; no code changes

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-cdn-03 --n 1` → pass_rate=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automation test history with a passing architecture test result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->