### PR TITLE
chore(evals): record automation run 20260426-150000-orgst3

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -85,3 +85,4 @@
 {"run_id":"20260426-120000-cdn1","question_id":"arch-cdn-03","category":"architecture","difficulty":"medium","status":"pass","ts":"2026-04-26T12:05:00Z"}
 {"run_id":"20260426-130000-nethom2","question_id":"net-home-01","category":"network","difficulty":"medium","status":"no-change","ts":"2026-04-26T13:10:00Z"}
 {"run_id":"20260426-140000-mindrct2","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-26T14:05:00Z"}
+{"run_id":"20260426-150000-orgst3","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T15:05:00Z"}


### PR DESCRIPTION
## Summary
- automation-loop run for `org-startup-01` (org / easy) → **pass**
- rubric total 0.905, node_count=9 fit, edge_count=8 fit, concept_coverage=1
- no code changes — history-only commit

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id org-startup-01 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new automation run record to evaluation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->