### PR TITLE
chore(evals): record automation run 20260426-170000-erdec1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -87,3 +87,4 @@
 {"run_id":"20260426-140000-mindrct2","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-26T14:05:00Z"}
 {"run_id":"20260426-150000-orgst3","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T15:05:00Z"}
 {"run_id":"20260426-160000-flowcc1","question_id":"flow-concurrent-06","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-26T16:05:00Z"}
+{"run_id":"20260426-170000-erdec1","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-26T17:05:00Z"}


### PR DESCRIPTION
## Summary
- erd-ecom-02 (erd/medium) 자동 루프 통과 결과 기록.
- verdict pass (total 0.905), 코드 변경 없음 → history-only chore PR.

## Test plan
- [x] pnpm --filter drawcast-evals eval -- --id erd-ecom-02 --n 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)