### PR TITLE
chore(evals): record automation run 20260426-200000-arch3t1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -88,3 +88,4 @@
 {"run_id":"20260426-150000-orgst3","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-26T15:05:00Z"}
 {"run_id":"20260426-160000-flowcc1","question_id":"flow-concurrent-06","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-26T16:05:00Z"}
 {"run_id":"20260426-170000-erdec1","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-26T17:05:00Z"}
+{"run_id":"20260426-200000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-26T20:05:00Z"}


### PR DESCRIPTION
## Summary
- Append history entry for arch-3tier-01 (architecture/easy) — pass on first run, no code change.

## Test plan
- [x] E2E: `pnpm --filter drawcast-evals eval -- --id arch-3tier-01 --n 1` → verdict=pass (rubric structure/labels/intent_fit=5, layout/readability=3; node_count=3 fit=1, edge_count=4 fit=1, concept_coverage=1, overlap_pairs=0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run records with the latest evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->