### PR TITLE
chore(evals): record automation run 20260426-210000-seqws1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -89,3 +89,4 @@
 {"run_id":"20260426-160000-flowcc1","question_id":"flow-concurrent-06","category":"flowchart","difficulty":"hard","status":"pass","ts":"2026-04-26T16:05:00Z"}
 {"run_id":"20260426-170000-erdec1","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-26T17:05:00Z"}
 {"run_id":"20260426-200000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-26T20:05:00Z"}
+{"run_id":"20260426-210000-seqws1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-26T21:05:00Z"}


### PR DESCRIPTION
## Summary
- question_id: `seq-websocket-02` (sequence / easy)
- status: **pass** — rubric total 0.905, structure/labels/layout/readability/intent_fit = 4/5/3/3/4
- 코드 변경 없음. `_history.jsonl`만 한 줄 추가.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id seq-websocket-02 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation test run logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->