### PR TITLE
chore(evals): record automation run 20260426-220000-sttcp1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -90,3 +90,4 @@
 {"run_id":"20260426-170000-erdec1","question_id":"erd-ecom-02","category":"erd","difficulty":"medium","status":"pass","ts":"2026-04-26T17:05:00Z"}
 {"run_id":"20260426-200000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-26T20:05:00Z"}
 {"run_id":"20260426-210000-seqws1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-26T21:05:00Z"}
+{"run_id":"20260426-220000-sttcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T22:05:00Z"}


### PR DESCRIPTION
## Summary
- automation loop run `20260426-220000-sttcp1`
- question_id: `state-tcp-02` (state, medium)
- status: pass — rubric pass + structure metric fit, no code changes

## Test plan
- [x] Eval result: rubric=pass, node_count=11 (fit), edge_count=18 (fit), concept_coverage=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded an additional passing automation run entry to the system history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->