### PR TITLE
chore(evals): record automation run 20260426-230000-vpc2

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -91,3 +91,4 @@
 {"run_id":"20260426-200000-arch3t1","question_id":"arch-3tier-01","category":"architecture","difficulty":"easy","status":"pass","ts":"2026-04-26T20:05:00Z"}
 {"run_id":"20260426-210000-seqws1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-26T21:05:00Z"}
 {"run_id":"20260426-220000-sttcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T22:05:00Z"}
+{"run_id":"20260426-230000-vpc2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T23:05:00Z"}


### PR DESCRIPTION
## Summary
- Records automation loop run `20260426-230000-vpc2` to `_history.jsonl`
- Scenario: `net-vpc-02` (network/hard) — verdict **pass**, total 0.81
- No code changes (rubric pass + structure metric fit)

## Test plan
- [x] E2E single-case eval ran cleanly: `pnpm --filter drawcast-evals eval -- --id net-vpc-02 --n 1`
- [x] history entry append-only, single line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Recorded successful completion of network infrastructure validation test runs in automation history, improving visibility into testing outcomes and maintaining comprehensive execution records for infrastructure monitoring purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->