### PR TITLE
chore(evals): record automation run 20260427-000000-fretry1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -92,3 +92,4 @@
 {"run_id":"20260426-210000-seqws1","question_id":"seq-websocket-02","category":"sequence","difficulty":"easy","status":"pass","ts":"2026-04-26T21:05:00Z"}
 {"run_id":"20260426-220000-sttcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T22:05:00Z"}
 {"run_id":"20260426-230000-vpc2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T23:05:00Z"}
+{"run_id":"20260427-000000-fretry1","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-27T00:05:00Z"}


### PR DESCRIPTION
## Summary
- Append automation history line for run `20260427-000000-fretry1`
- question_id: `flow-retry-05` (flowchart / easy)
- status: **pass** (no code changes; first-attempt rubric pass + structure fit)

## Test plan
- [x] PNG visually verified — clear branch + retry loop, no overlaps
- [x] structure metrics within range (nodes 7, edges 7, concept_coverage 1)
- [x] rubric verdict pass (5/5/3/3/5)