### PR TITLE
chore(evals): record automation run 20260427-010000-mind1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -93,3 +93,4 @@
 {"run_id":"20260426-220000-sttcp1","question_id":"state-tcp-02","category":"state","difficulty":"medium","status":"pass","ts":"2026-04-26T22:05:00Z"}
 {"run_id":"20260426-230000-vpc2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T23:05:00Z"}
 {"run_id":"20260427-000000-fretry1","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-27T00:05:00Z"}
+{"run_id":"20260427-010000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-27T01:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for `mind-react-01` (mind/medium)
- Result: **pass** — rubric total 0.952, structure metrics all green (overlap=0, fits=1)
- No code change required; appending history entry only.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id mind-react-01 --n 1` → pass
- [x] PNG visually inspected (center "렌더 최적화" + 5 branches, no overlap, no truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation run records with the latest evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->