### PR TITLE
chore(evals): record automation run 20260427-020000-orgst1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -94,3 +94,4 @@
 {"run_id":"20260426-230000-vpc2","question_id":"net-vpc-02","category":"network","difficulty":"hard","status":"pass","ts":"2026-04-26T23:05:00Z"}
 {"run_id":"20260427-000000-fretry1","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-27T00:05:00Z"}
 {"run_id":"20260427-010000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-27T01:05:00Z"}
+{"run_id":"20260427-020000-orgst1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-27T02:05:00Z"}


### PR DESCRIPTION
## Summary
- org-startup-01 (org/easy) automation run 결과: pass (total 0.857)
- 코드 변경 없이 _history.jsonl 1줄 append

## Test plan
- [x] eval pass: structure/labels/intent_fit 양호, overlap_pairs=0