### PR TITLE
chore(evals): record automation run 20260427-030000-archev1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -95,3 +95,4 @@
 {"run_id":"20260427-000000-fretry1","question_id":"flow-retry-05","category":"flowchart","difficulty":"easy","status":"pass","ts":"2026-04-27T00:05:00Z"}
 {"run_id":"20260427-010000-mind1","question_id":"mind-react-01","category":"mind","difficulty":"medium","status":"pass","ts":"2026-04-27T01:05:00Z"}
 {"run_id":"20260427-020000-orgst1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-27T02:05:00Z"}
+{"run_id":"20260427-030000-archev1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-27T03:05:00Z"}


### PR DESCRIPTION
## Summary
- automation run `20260427-030000-archev1`
- scenario: `arch-eventdriven-05` (architecture / hard)
- verdict: **pass** (total 0.96, structure 5 / labels 5 / intent_fit 5)
- code change: none

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id arch-eventdriven-05 --n 1` → pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Recorded completion of test run for architecture-based evaluation scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->