### PR TITLE
chore(evals): record automation run 20260427-050000-erdhsp1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -97,3 +97,4 @@
 {"run_id":"20260427-020000-orgst1","question_id":"org-startup-01","category":"org","difficulty":"easy","status":"pass","ts":"2026-04-27T02:05:00Z"}
 {"run_id":"20260427-030000-archev1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-27T03:05:00Z"}
 {"run_id":"20260427-040000-seqllm1","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-27T04:05:00Z"}
+{"run_id":"20260427-050000-erdhsp1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-27T05:05:00Z"}


### PR DESCRIPTION
## Summary
- Append automation loop history entry for `erd-hospital-03` (erd / hard).
- Verdict: **pass** (rubric total 0.948), no code changes required.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id erd-hospital-03 --n 1` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation run history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->