### PR TITLE
chore(evals): record automation run 20260427-060000-stord1

### DIFF
--- a/evals/automation-runs/_history.jsonl
+++ b/evals/automation-runs/_history.jsonl
@@ -98,3 +98,4 @@
 {"run_id":"20260427-030000-archev1","question_id":"arch-eventdriven-05","category":"architecture","difficulty":"hard","status":"pass","ts":"2026-04-27T03:05:00Z"}
 {"run_id":"20260427-040000-seqllm1","question_id":"seq-llm-05","category":"sequence","difficulty":"hard","status":"pass","ts":"2026-04-27T04:05:00Z"}
 {"run_id":"20260427-050000-erdhsp1","question_id":"erd-hospital-03","category":"erd","difficulty":"hard","status":"pass","ts":"2026-04-27T05:05:00Z"}
+{"run_id":"20260427-060000-stord1","question_id":"state-order-01","category":"state","difficulty":"easy","status":"pass","ts":"2026-04-27T06:05:00Z"}


### PR DESCRIPTION
## Summary
- Automation loop run for `state-order-01` (state/easy) — verdict **pass** with no code changes.
- Appends one line to `evals/automation-runs/_history.jsonl` so subsequent loops can apply diversification rules.

## Test plan
- [x] `pnpm --filter drawcast-evals eval -- --id state-order-01 --n 1` → pass_rate=1, structure metrics all fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)